### PR TITLE
Use libressl instead of openssl on Alpine

### DIFF
--- a/install-php-extensions
+++ b/install-php-extensions
@@ -563,9 +563,14 @@ expandPackagesToBeInstalled () {
 	expandPackagesToBeInstalled_result=''
 	case "$(getDistro)" in
 		alpine)
+			expandPackagesToBeInstalled_log="$(apk add --simulate $@ 2>&1)"
+			if test -n "$(printf '%s' "$expandPackagesToBeInstalled_log" | grep -E '^ERROR:')"; then
+				printf 'Failed to list the whole package list for %s\n\n%s\n' "$@" "$expandPackagesToBeInstalled_log" >&2
+				exit 1
+			fi
 			IFS='
 '
-			for expandPackagesToBeInstalled_line in $(apk add --simulate $@); do
+			for expandPackagesToBeInstalled_line in $expandPackagesToBeInstalled_log; do
 				if test -n "$(printf '%s' "$expandPackagesToBeInstalled_line" | grep -E '^\([0-9]*/[0-9]*) Installing ')"; then
 					expandPackagesToBeInstalled_result="$expandPackagesToBeInstalled_result $(printf '%s' "$expandPackagesToBeInstalled_line" | cut -d ' ' -f 3)"
 				fi
@@ -573,10 +578,15 @@ expandPackagesToBeInstalled () {
 			resetIFS
 			;;
 		debian)
+			expandPackagesToBeInstalled_log="$(DEBIAN_FRONTEND=noninteractive apt-get install -sy $@ 2>&1)"
+			if test -n "$(printf '%s' "$expandPackagesToBeInstalled_log" | grep -E '^E:')"; then
+				printf 'Failed to list the whole package list for %s\n\n%s\n' "$@" "$expandPackagesToBeInstalled_log" >&2
+				exit 1
+			fi
 			expandPackagesToBeInstalled_inNewPackages=0
 			IFS='
 '
-			for expandPackagesToBeInstalled_line in $(DEBIAN_FRONTEND=noninteractive apt-get install -sy $@); do
+			for expandPackagesToBeInstalled_line in $expandPackagesToBeInstalled_log; do
 				if test $expandPackagesToBeInstalled_inNewPackages -eq 0; then
 					if test "$expandPackagesToBeInstalled_line" = 'The following NEW packages will be installed:'; then
 						expandPackagesToBeInstalled_inNewPackages=1

--- a/install-php-extensions
+++ b/install-php-extensions
@@ -269,7 +269,7 @@ buildRequiredPackageLists () {
 				;;
 			imap@alpine)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent c-client"
-				if test -z "$(apk info | grep -E ^libssl)"; then
+				if test -z "$(apk info 2>/dev/null | grep -E ^libssl)"; then
 					buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libssl1.0"
 				fi
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile krb5-dev imap-dev libressl-dev"
@@ -330,8 +330,10 @@ buildRequiredPackageLists () {
 				;;
 			mongodb@alpine)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent icu-libs libsasl snappy"
-				if test -z "$(apk info | grep -E ^libssl)"; then
+				if test -z "$(apk info 2>/dev/null | grep -E ^libssl)"; then
 					buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libssl1.0"
+				elif test -z "$(apk info 2>/dev/null | grep -E '^libressl.*-libtls')"; then
+					buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libressl2.7-libtls"
 				fi
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile icu-dev cyrus-sasl-dev snappy-dev libressl-dev zlib-dev"
 				;;

--- a/install-php-extensions
+++ b/install-php-extensions
@@ -181,6 +181,9 @@ buildRequiredPackageLists () {
 	buildRequiredPackageLists_volatile=''
 	buildRequiredPackageLists_distro="$(getDistro)"
 	buildRequiredPackageLists_phpv=$1
+	if test "$buildRequiredPackageLists_distro" = 'alpine'; then
+		buildRequiredPackageLists_volatile="$PHPIZE_DEPS"
+	fi
 	while :; do
 		if test $# -lt 2; then
 			break
@@ -189,14 +192,11 @@ buildRequiredPackageLists () {
 		case "$1@$buildRequiredPackageLists_distro" in
 			amqp@alpine)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent rabbitmq-c"
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS rabbitmq-c-dev"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile rabbitmq-c-dev"
 				;;
 			amqp@debian)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent librabbitmq4"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile librabbitmq-dev libssh-dev"
-				;;
-			apcu@alpine)
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS"
 				;;
 			bz2@alpine)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libbz2"
@@ -206,7 +206,7 @@ buildRequiredPackageLists () {
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libbz2-dev"
 				;;
 			cmark@alpine)
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS cmake"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile cmake"
 				;;
 			cmark@debian)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile cmake"
@@ -254,17 +254,14 @@ buildRequiredPackageLists () {
 				;;
 			grpc@alpine)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libstdc++"
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS zlib-dev"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile zlib-dev"
 				;;
 			grpc@debian)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile zlib1g-dev"
 				;;
-			igbinary@alpine)
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS"
-				;;
 			imagick@alpine)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent imagemagick"
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS imagemagick-dev"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile imagemagick-dev"
 				;;
 			imagick@debian)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libmagickwand-6.q16-?"
@@ -282,7 +279,7 @@ buildRequiredPackageLists () {
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libc-client-dev libkrb5-dev"
 				;;
 			interbase@alpine)
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS icu-dev ncurses-dev"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile icu-dev ncurses-dev"
 				;;
 			interbase@debian)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libfbclient2"
@@ -303,7 +300,7 @@ buildRequiredPackageLists () {
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libldap2-dev"
 				;;
 			mcrypt@alpine)
-				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent $PHPIZE_DEPS libmcrypt"
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libmcrypt"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libmcrypt-dev"
 				;;
 			mcrypt@debian)
@@ -311,14 +308,14 @@ buildRequiredPackageLists () {
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libmcrypt-dev"
 				;;
 			memcache@alpine)
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS zlib-dev"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile zlib-dev"
 				;;
 			memcache@debian)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile zlib1g-dev"
 				;;
 			memcached@alpine)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libmemcached-libs"
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS libmemcached-dev zlib-dev"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libmemcached-dev zlib-dev"
 				;;
 			memcached@debian)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libmemcachedutil2"
@@ -326,7 +323,7 @@ buildRequiredPackageLists () {
 				;;
 			mongo@alpine)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libsasl libssl1.0"
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS openssl-dev cyrus-sasl-dev"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile openssl-dev cyrus-sasl-dev"
 				;;
 			mongo@debian)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libssl-dev libsasl2-dev"
@@ -336,14 +333,11 @@ buildRequiredPackageLists () {
 				if test -z "$(apk info | grep -E ^libssl)"; then
 					buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libssl1.0"
 				fi
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS icu-dev cyrus-sasl-dev snappy-dev openssl-dev zlib-dev"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile icu-dev cyrus-sasl-dev snappy-dev openssl-dev zlib-dev"
 				;;
 			mongodb@debian)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libsnappy1v5"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libicu-dev libsasl2-dev libsnappy-dev libssl-dev zlib1g-dev"
-				;;
-			msgpack@alpine)
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS"
 				;;
 			mssql@alpine)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent freetds"
@@ -355,20 +349,11 @@ buildRequiredPackageLists () {
 				;;
 			odbc@alpine)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent unixodbc"
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS unixodbc-dev"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile unixodbc-dev"
 				;;
 			odbc@debian)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libodbc1"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile unixodbc-dev"
-				;;
-			opencensus@alpine)
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS"
-				;;
-			parallel@alpine)
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS"
-				;;
-			pcov@alpine)
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS"
 				;;
 			pdo_dblib@alpine)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent freetds"
@@ -379,7 +364,7 @@ buildRequiredPackageLists () {
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile freetds-dev"
 				;;
 			pdo_firebird@alpine)
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS icu-dev ncurses-dev"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile icu-dev ncurses-dev"
 				;;
 			pdo_firebird@debian)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libfbclient2"
@@ -387,7 +372,7 @@ buildRequiredPackageLists () {
 				;;
 			pdo_odbc@alpine)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent unixodbc"
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS unixodbc-dev"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile unixodbc-dev"
 				;;
 			pdo_odbc@debian)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libodbc1"
@@ -403,7 +388,7 @@ buildRequiredPackageLists () {
 				;;
 			pdo_sqlsrv@alpine)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libstdc++ unixodbc"
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS unixodbc-dev"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile unixodbc-dev"
 				;;
 			pdo_sqlsrv@debian)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libodbc1 odbcinst"
@@ -417,9 +402,6 @@ buildRequiredPackageLists () {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libpq5"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libpq-dev"
 				;;
-			protobuf@alpine)
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS"
-				;;
 			pspell@alpine)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent aspell-libs"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile aspell-dev"
@@ -428,12 +410,9 @@ buildRequiredPackageLists () {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libaspell15"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libpspell-dev"
 				;;
-			pthreads@alpine)
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS"
-				;;
 			rdkafka@alpine)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent librdkafka"
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS librdkafka-dev"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile librdkafka-dev"
 				;;
 			rdkafka@debian)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent librdkafka++1"
@@ -446,9 +425,6 @@ buildRequiredPackageLists () {
 			recode@debian)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent librecode0"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile librecode-dev"
-				;;
-			redis@alpine)
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS"
 				;;
 			snmp@alpine)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent net-snmp-libs"
@@ -466,7 +442,7 @@ buildRequiredPackageLists () {
 				;;
 			solr@alpine)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent"
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS curl-dev libxml2-dev"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile curl-dev libxml2-dev"
 				;;
 			solr@debian)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libcurl3-gnutls"
@@ -474,15 +450,15 @@ buildRequiredPackageLists () {
 				;;
 			sqlsrv@alpine)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libstdc++ unixodbc"
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS unixodbc-dev"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile unixodbc-dev"
 				;;
 			sqlsrv@debian)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent unixodbc"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile unixodbc-dev"
 				;;
 			ssh2@alpine)
-				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent $PHPIZE_DEPS libssh2"
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS libssh2-dev"
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libssh2"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libssh2-dev"
 				;;
 			ssh2@debian)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libssh2-1-dev"
@@ -503,15 +479,9 @@ buildRequiredPackageLists () {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libtidy5*"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libtidy-dev"
 				;;
-			timezonedb@alpine)
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS"
-				;;
-			uopz@alpine)
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS"
-				;;
 			uuid@alpine)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libuuid"
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS util-linux-dev"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile util-linux-dev"
 				;;
 			uuid@debian)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile uuid-dev"
@@ -521,9 +491,6 @@ buildRequiredPackageLists () {
 				;;
 			wddx@debian)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libxml2-dev"
-				;;
-			xdebug@alpine)
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS"
 				;;
 			xmlrpc@alpine)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libxml2-dev"
@@ -540,8 +507,8 @@ buildRequiredPackageLists () {
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libxslt-dev"
 				;;
 			yaml@alpine)
-				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent $PHPIZE_DEPS yaml"
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS yaml-dev"
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent yaml"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile yaml-dev"
 				;;
 			yaml@debian)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libyaml-0-2"
@@ -549,7 +516,7 @@ buildRequiredPackageLists () {
 				;;
 			zip@alpine)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libzip"
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS cmake gnutls-dev libzip-dev openssl-dev zlib-dev"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile cmake gnutls-dev libzip-dev openssl-dev zlib-dev"
 				;;
 			zip@debian)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libzip4 libmbedtls1?"

--- a/install-php-extensions
+++ b/install-php-extensions
@@ -272,7 +272,7 @@ buildRequiredPackageLists () {
 				if test -z "$(apk info | grep -E ^libssl)"; then
 					buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libssl1.0"
 				fi
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile krb5-dev imap-dev openssl openssl-dev"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile krb5-dev imap-dev libressl-dev"
 				;;
 			imap@debian)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libc-client2007e"
@@ -323,7 +323,7 @@ buildRequiredPackageLists () {
 				;;
 			mongo@alpine)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libsasl libssl1.0"
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile openssl-dev cyrus-sasl-dev"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libressl-dev cyrus-sasl-dev"
 				;;
 			mongo@debian)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libssl-dev libsasl2-dev"
@@ -333,7 +333,7 @@ buildRequiredPackageLists () {
 				if test -z "$(apk info | grep -E ^libssl)"; then
 					buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libssl1.0"
 				fi
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile icu-dev cyrus-sasl-dev snappy-dev openssl-dev zlib-dev"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile icu-dev cyrus-sasl-dev snappy-dev libressl-dev zlib-dev"
 				;;
 			mongodb@debian)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libsnappy1v5"
@@ -516,7 +516,7 @@ buildRequiredPackageLists () {
 				;;
 			zip@alpine)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libzip"
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile cmake gnutls-dev libzip-dev openssl-dev zlib-dev"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile cmake gnutls-dev libzip-dev libressl-dev zlib-dev"
 				;;
 			zip@debian)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libzip4 libmbedtls1?"


### PR DESCRIPTION
libressl is a dependency of rabbitmq-c, and openssl conflicts with libressl