### PR TITLE
fix amqp for jessie

### DIFF
--- a/install-php-extensions
+++ b/install-php-extensions
@@ -195,12 +195,15 @@ buildRequiredPackageLists () {
 			buildRequiredPackageLists_volatile="$PHPIZE_DEPS"
 			;;
 		debian)
-			if test -n "$(apt-cache search libssl1.0 | grep -E ^libssl1\.0)"; then
-				# Debian 9, uses libssl1.0 instead of libssl, due to conflict with libssh-dev
-				buildRequiredPackageLists_libssldev='libssl1.0-dev'
-			else
-				buildRequiredPackageLists_libssldev='libssl-dev'
-			fi
+			case "$(getDistroVersion)" in
+				debian@9)
+					# Debian 9, uses libssl1.0 instead of libssl, due to conflict with libssh-dev
+					buildRequiredPackageLists_libssldev='libssl1.0-dev'
+					;;
+				*)
+					buildRequiredPackageLists_libssldev='libssl-dev'
+					;;
+			esac
 			;;
 	esac
 	while :; do
@@ -214,7 +217,14 @@ buildRequiredPackageLists () {
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile rabbitmq-c-dev"
 				;;
 			amqp@debian)
-				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent librabbitmq4"
+				case "$(getDistroVersion)" in
+					debian@8)
+						buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent librabbitmq1"
+						;;
+					*)
+						buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent librabbitmq4"
+						;;
+				esac
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile librabbitmq-dev libssh-dev"
 				;;
 			bz2@alpine)


### PR DESCRIPTION
@mlocati I'm doing some further tests locally

libssl1.0-dev is present only in stretch
https://packages.debian.org/stretch/libssl1.0-dev

librabbitmq4 is not present in jessie, but librabbitmq-dev is
https://packages.debian.org/stretch/librabbitmq4
https://packages.debian.org/jessie/librabbitmq-dev


Humh is jessie supported anymore? zip is not installable in jessie, I don't use jessie anymore.

I tested on `7.1-cli-jessie` with `igbinary redis amqp apcu bcmath gettext gmp intl opcache pdo_dblib pdo_sqlite pdo_pgsql pgsql memcached imagick rdkafka shmop sockets sysvmsg sysvsem sysvshm wddx xml xsl zip ldap`
```
FAILED TO LIST THE WHOLE PACKAGE LIST FOR
librabbitmq4 libsybdb5 libpq5 libpq5 libmemcachedutil2 libmagickwand-6.q16-? librdkafka++1 libxslt1.1 libzip4 libmbedtls1?

COMMAND OUTPUT:
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package librabbitmq4
E: Unable to locate package libzip4
E: Unable to locate package libmbedtls1?
E: Couldn't find any package by regex 'libmbedtls1?'

E: apt-get failed
FAILED TO LIST THE WHOLE PACKAGE LIST FOR
librabbitmq-dev libssh-dev libgmp-dev libicu-dev freetds-dev libpq-dev libpq-dev libmemcached-dev zlib1g-dev libmagickwand-dev librdkafka-dev libxml2-dev libxslt-dev cmake gnutls-dev libssl-dev libzip-dev libbz2-dev libmbedtls-dev zlib1g-dev libldap2-dev

COMMAND OUTPUT:
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package libmbedtls-dev

E: apt-get failed
### INSTALLING REQUIRED PACKAGES ###
# Packages to be kept after installation:
# Packages to be used only for installation:
```