### PR TITLE
Add compatibility memcached with msgpack

### DIFF
--- a/install-php-extensions
+++ b/install-php-extensions
@@ -1304,7 +1304,11 @@ installPECLModule() {
 	case "$2" in
 		http)
 			# http must be loaded after raphf and propro
-			docker-php-ext-enable --ini-name "zzz-$2.ini" "$2"
+			docker-php-ext-enable --ini-name "xx-php-ext-$2.ini" "$2"
+			;;
+		memcached)
+			# memcached must be loaded after msgpack
+			docker-php-ext-enable --ini-name "xx-php-ext-$2.ini" "$2"
 			;;
 		*)
 			docker-php-ext-enable "$2"


### PR DESCRIPTION
Fixed `Unable to load dynamic library '/usr/local/lib/php/extensions/no-debug-non-zts-20160303/memcached.so' - Error relocating /usr/local/lib/php/extensions/no-debug-non-zts-20160303/memcached.so: php_msgpack_serialize: symbol not found in Unknown on line 0`