### PR TITLE
Speedup pecl builds on multicore systems

### DIFF
--- a/install-php-extensions
+++ b/install-php-extensions
@@ -1339,7 +1339,7 @@ installPECLModule() {
 			printf '  (installing version %s)\n' "$installPECLModule_actual"
 		fi
 		pecl channel-update pecl.php.net || true
-		printf "$installPECLModule_stdin" | pecl install "$installPECLModule_actual"
+		printf "$installPECLModule_stdin" | MAKE="make -j$(nproc)" pecl install "$installPECLModule_actual"
 	fi
 	case "$1" in
 		apcu_bc)


### PR DESCRIPTION
Speedup pecl builds by adding MAKE="make -j$(nproc)" so it can make use of more than 1 core

This especially helps speeding up the build of the grpc extension (on my system it reduces the total build time from ~15 minutes down to ~3.5 minutes)