### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ FROM php:7.2-cli
 
 ADD https://raw.githubusercontent.com/mlocati/docker-php-extension-installer/master/install-php-extensions /usr/local/bin/
 
-RUN chmod uga+x /usr/local/bin/install-php-extensions && sync && \
+RUN chmod +x /usr/local/bin/install-php-extensions && sync && \
     install-php-extensions gd xdebug
 ```
 


### PR DESCRIPTION
`chmod +x` gets the same result that `chmod a+x` and `chmod uga+x`.

> Classes of users are used to distinguish to whom the permissions apply. If no classes are specified "all" is implied. The classes are represented by one or more of the following letters:

Reference | Class | Description
------------ | ------------- | -------------
u | user | file owner
g | group | members of the file's group
o | others | users who are neither the file's owner nor members of the file's group
a | all | all three of the above, same as ugo