### PR TITLE
[documentation] Add caveat on COPY cached image

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr
 RUN install-php-extensions gd xdebug
 ```
 
+#### *Beware*
+
+*When building locally, be sure you have the latest version of the `mlocati/php-extension-installer` image by running :*
+
+```sh
+docker pull mlocati/php-extension-installer
+```
+
+*otherwise the `COPY` instruction could use a previously downloaded, outdated version of the image stored in the local docker cache.*
+
+
 ### Installing a specific version of an extension
 
 Simply append `-<version>` to the module name.


### PR DESCRIPTION
- Add a caveat on cached image pitfall in the `COPY` section of the `README`

Following up to the point discussed in https://github.com/mlocati/docker-php-extension-installer/issues/242#issuecomment-756007021