### PR TITLE
Fix installing igbinary with PHP 8

### DIFF
--- a/install-php-extensions
+++ b/install-php-extensions
@@ -2102,7 +2102,7 @@ configureInstaller() {
 			if ! stringInList 'zip' "$PHP_PREINSTALLED_MODULES"; then
 				PHP_MODULES_TO_INSTALL="zip $(removeStringFromList 'zip' "$PHP_MODULES_TO_INSTALL")"
 			fi
-			if anyStringInList 'swoole xdebug xhprof pdo_sqlsrv sqlsrv' "$PHP_MODULES_TO_INSTALL"; then
+			if anyStringInList 'swoole xdebug xhprof pdo_sqlsrv sqlsrv igbinary' "$PHP_MODULES_TO_INSTALL"; then
 				USE_PICKLE=2
 			else
 				curl -sSLf https://github.com/FriendsOfPHP/pickle/releases/latest/download/pickle.phar -o /tmp/pickle


### PR DESCRIPTION
Thanks to https://github.com/FriendsOfPHP/pickle/pull/201 pickle is now able parse versions more correctly.

Closes #248