### PR TITLE
Use recent smbclient version even on old Alpine versions

### DIFF
--- a/install-php-extensions
+++ b/install-php-extensions
@@ -1810,15 +1810,6 @@ installRemoteModule() {
 				addConfigureOption 'enable-redis-zstd' 'yes'
 			fi
 			;;
-		smbclient)
-			if test -z "$installRemoteModule_version"; then
-				case "$DISTRO_VERSION" in
-					alpine@3.7 | alpine@3.8 | alpine@3.9)
-						installRemoteModule_version=1.0.1
-						;;
-				esac
-			fi
-			;;
 		snuffleupagus)
 			if test -z "$installRemoteModule_version"; then
 				installRemoteModule_version=0.7.0


### PR DESCRIPTION
Thanks to https://github.com/eduardok/libsmbclient-php/issues/79 it's now possible again even on old Alpine versions.