### PR TITLE
Run CI on push as well

### DIFF
--- a/.github/workflows/test-extensions.yml
+++ b/.github/workflows/test-extensions.yml
@@ -2,6 +2,7 @@ name: Test extensions
 
 on:
   - pull_request
+  - push
 
 jobs:
   check_syntax_data:


### PR DESCRIPTION
allow easier development without the need to open PR first