### PR TITLE
Request: add --no-install-recommends

### DIFF
--- a/install-php-extensions
+++ b/install-php-extensions
@@ -1118,7 +1118,7 @@ installRequiredPackages() {
 			apk add $PACKAGES_PERSISTENT $PACKAGES_VOLATILE
 			;;
 		debian)
-			DEBIAN_FRONTEND=noninteractive apt-get install -qq -y $PACKAGES_PERSISTENT $PACKAGES_VOLATILE
+			DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -qq -y $PACKAGES_PERSISTENT $PACKAGES_VOLATILE
 			;;
 	esac
 }
@@ -2406,7 +2406,7 @@ cleanup() {
 		case "$DISTRO" in
 			debian)
 				printf '### RESTORING PREVIOUSLY INSTALLED PACKAGES ###\n'
-				DEBIAN_FRONTEND=noninteractive apt-get install --no-upgrade -qqy $PACKAGES_PREVIOUS
+				DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --no-upgrade -qqy $PACKAGES_PREVIOUS
 				;;
 		esac
 	fi

--- a/install-php-extensions
+++ b/install-php-extensions
@@ -1027,7 +1027,7 @@ expandPackagesToBeInstalled() {
 			resetIFS
 			;;
 		debian)
-			expandPackagesToBeInstalled_log="$(DEBIAN_FRONTEND=noninteractive apt-get install -sy $@ 2>&1 || printf '\nE: apt-get failed\n')"
+			expandPackagesToBeInstalled_log="$(DEBIAN_FRONTEND=noninteractive apt-get install -sy --no-install-recommends $@ 2>&1 || printf '\nE: apt-get failed\n')"
 			if test -n "$(printf '%s' "$expandPackagesToBeInstalled_log" | grep -E '^E:')"; then
 				printf 'FAILED TO LIST THE WHOLE PACKAGE LIST FOR\n' >&2
 				printf '%s ' "$@" >&2

--- a/install-php-extensions
+++ b/install-php-extensions
@@ -1257,7 +1257,7 @@ installMicrosoftSqlServerODBC() {
 				DEBIAN_FRONTEND=noninteractive apt-get -q update
 			fi
 			printf -- '- installing the APT package\n'
-			DEBIAN_FRONTEND=noninteractive ACCEPT_EULA=Y apt-get -qy install '^msodbcsql[0-9]+$'
+			DEBIAN_FRONTEND=noninteractive ACCEPT_EULA=Y apt-get -qy --no-install-recommends install '^msodbcsql[0-9]+$'
 			;;
 	esac
 }


### PR DESCRIPTION
I'd like to propose a minor optimization for installing packages by using --no-install-recommends for apt. 

```
       --no-install-recommends
           Do not consider recommended packages as a dependency for
           installing. Configuration Item: APT::Install-Recommends.
```

Pros:
- faster download;
- less image size;

Cons:
- someone can rely on some of recommended and thus installed packages but this is going to be a really rare case and also it's easily fixed with adding a separate `apt-get install` instruction;

As an example: a diff of my own installation log after I added --no-install-recommends:
```patch
# Packages to be used only for installation:
-bzip2-doc
cmake
cmake-data
icu-devtools
libarchive13
libbz2-dev
libevent-2.1-6
libfreetype6-dev
libgmp-dev
libgmpxx4ldbl
libgnutls-dane0
libgnutls-openssl27
libgnutls28-dev
libgnutlsxx28
libicu-dev
libidn2-dev
libjpeg62-turbo-dev
libjsoncpp1
libmbedtls-dev
libp11-kit-dev
libpng-dev
-libpng-tools
libpq-dev
libprocps7
libpthread-stubs0-dev
librabbitmq-dev
librhash0
libssh-4
libssh-dev
libssl-dev
libtasn1-6-dev
-libtasn1-doc
libunbound8
libuv1
libwebp-dev
libwebpdemux2
libwebpmux3
libx11-dev
libxau-dev
libxcb1-dev
libxdmcp-dev
libxml2-dev
libxpm-dev
libzip-dev
nettle-dev
procps
-psmisc
x11proto-core-dev
x11proto-dev
xorg-sgml-doctools
xtrans-dev
zlib1g-dev
```