### PR TITLE
Readme: Remove "on the fly example"

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,6 @@ With the first method you are sure you'll always get the very latest version of 
 
 For example, here are two `Dockerfile`s that install the GD and xdebug PHP extensions:
 
-### Downloading the script on the fly
-
-```Dockerfile
-FROM php:7.2-cli
-
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
-
-RUN chmod +x /usr/local/bin/install-php-extensions && sync && \
-    install-php-extensions gd xdebug
-```
-
 ### Copying the script from a Docker image
 
 ```Dockerfile


### PR DESCRIPTION
The `COPY` solution is what should be used because it allows the layer to be cached.

The other solution included a weird `sync` hack, which without an actual bug to investigate should be removed:
- https://github.com/mlocati/docker-php-extension-installer/commit/eca94d432b66589fed91b79c1b8f5bdcfca45d26