### PR TITLE
Add libgomp as required package for imagemagick@alpine (Fixes #350)

### DIFF
--- a/install-php-extensions
+++ b/install-php-extensions
@@ -580,7 +580,7 @@ buildRequiredPackageLists() {
 				fi
 				;;
 			imagick@alpine)
-				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent imagemagick"
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent imagemagick libgomp"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile imagemagick-dev"
 				;;
 			imagick@debian)


### PR DESCRIPTION
I'm not really sure why, but libgomp has become a required shared library for Imagick.