### PR TITLE
Fix apt package regexes on Debian

### DIFF
--- a/install-php-extensions
+++ b/install-php-extensions
@@ -425,7 +425,7 @@ buildRequiredPackageLists() {
 			buildRequiredPackageLists_libssldev='libssl1.0-dev'
 			;;
 		debian@*)
-			buildRequiredPackageLists_libssldev='libssl([0-9]+(\.[0-9]+)*)?-dev$'
+			buildRequiredPackageLists_libssldev='^libssl([0-9]+(\.[0-9]+)*)?-dev$'
 			;;
 	esac
 	if test $USE_PICKLE -gt 1; then
@@ -441,7 +441,7 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile rabbitmq-c-dev"
 				;;
 			amqp@debian)
-				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent librabbitmq[0-9]"
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^librabbitmq[0-9]*$"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile librabbitmq-dev libssh-dev"
 				;;
 			bz2@alpine)
@@ -462,7 +462,7 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile db-dev"
 				;;
 			dba@debian)
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libdb5.3-dev"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile ^libdb5\.3-dev$"
 				if test $PHP_MAJMIN_VERSION -le 505; then
 					buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile patch"
 				fi
@@ -503,13 +503,13 @@ buildRequiredPackageLists() {
 				fi
 				;;
 			gd@debian)
-				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libfreetype6 libjpeg62-turbo libpng[0-9]+-[0-9]+$ libxpm4"
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libfreetype6 libjpeg62-turbo ^libpng[0-9]+-[0-9]+$ libxpm4"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libfreetype6-dev libjpeg62-turbo-dev libpng-dev libxpm-dev"
 				if test $PHP_MAJMIN_VERSION -le 506; then
-					buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libvpx[0-9]+$"
+					buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^libvpx[0-9]+$"
 					buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libvpx-dev"
 				else
-					buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libwebp[0-9]+$"
+					buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^libwebp[0-9]+$"
 					buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libwebp-dev"
 				fi
 				;;
@@ -518,7 +518,7 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile boost-dev gperf libmemcached-dev libevent-dev util-linux-dev"
 				;;
 			gearman@debian)
-				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libgearman[0-9]*$"
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^libgearman[0-9]*$"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libgearman-dev"
 				;;
 			geoip@alpine)
@@ -526,7 +526,7 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile geoip-dev"
 				;;
 			geoip@debian)
-				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libgeoip1[0-9]*$"
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^libgeoip1[0-9]*$"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libgeoip-dev"
 				;;
 			gettext@alpine)
@@ -538,7 +538,7 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile graphicsmagick-dev libtool"
 				;;
 			gmagick@debian)
-				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libgraphicsmagick(-q16-)?[0-9]*$"
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^libgraphicsmagick(-q16-)?[0-9]*$"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libgraphicsmagick1-dev"
 				;;
 			gmp@alpine)
@@ -553,8 +553,8 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile gpgme-dev"
 				;;
 			gnupg@debian)
-				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libgpgme[0-9]*$"
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libgpgme[0-9]*-dev"
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^libgpgme[0-9]*$"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile ^libgpgme[0-9]*-dev$"
 				;;
 			grpc@alpine)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libstdc++"
@@ -575,13 +575,13 @@ buildRequiredPackageLists() {
 				fi
 				;;
 			http@debian)
-				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libcurl3-gnutls libevent[0-9\.\-]*$"
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libcurl3-gnutls ^libevent[0-9\.\-]*$"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile zlib1g-dev libgnutls28-dev libcurl4-gnutls-dev libevent-dev"
 				if test $PHP_MAJMIN_VERSION -le 506; then
-					buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libidn1[0-9+]-dev$"
+					buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile ^libidn1[0-9+]-dev$"
 				else
-					buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libicu[0-9]+$ libidn2-[0-9+]$"
-					buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libicu-dev libidn2-[0-9+]-dev$"
+					buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^libicu[0-9]+$ ^libidn2-[0-9+]$"
+					buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libicu-dev ^libidn2-[0-9+]-dev$"
 				fi
 				;;
 			imagick@alpine)
@@ -589,7 +589,7 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile imagemagick-dev"
 				;;
 			imagick@debian)
-				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libmagickwand-6.q16-[0-9]+ libmagickcore-6.q16-[0-9]+-extra$"
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^libmagickwand-6.q16-[0-9]+$ ^libmagickcore-6.q16-[0-9]+-extra$"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libmagickwand-dev"
 				;;
 			imap@alpine)
@@ -620,7 +620,7 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile icu-dev"
 				;;
 			intl@debian)
-				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libicu[0-9]+$"
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^libicu[0-9]+$"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libicu-dev"
 				;;
 			ldap@alpine)
@@ -635,7 +635,7 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libmaxminddb-dev"
 				;;
 			maxminddb@debian)
-				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libmaxminddb[0-9]*$"
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^libmaxminddb[0-9]*$"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libmaxminddb-dev"
 				;;
 			mcrypt@alpine)
@@ -672,7 +672,7 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile icu-dev cyrus-sasl-dev snappy-dev $buildRequiredPackageLists_libssldev zlib-dev"
 				;;
 			mongodb@debian)
-				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libsnappy[0-9]+(v[0-9]+)?$ libicu[0-9]+$"
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^libsnappy[0-9]+(v[0-9]+)?$ ^libicu[0-9]+$"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libicu-dev libsasl2-dev libsnappy-dev $buildRequiredPackageLists_libssldev zlib1g-dev"
 				;;
 			mosquitto@alpine)
@@ -709,7 +709,7 @@ buildRequiredPackageLists() {
 				fi
 				;;
 			oci8@debian | pdo_oci@debian)
-				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libaio[0-9]*$"
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^libaio[0-9]*$"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile unzip"
 				;;
 			odbc@alpine | pdo_odbc@alpine)
@@ -756,7 +756,7 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile librdkafka-dev"
 				;;
 			rdkafka@debian)
-				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent librdkafka\+*[0-9]*$"
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^librdkafka\+*[0-9]*$"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile librdkafka-dev"
 				;;
 			recode@alpine)
@@ -790,7 +790,7 @@ buildRequiredPackageLists() {
 							## libzstd is too old (available: 1.1.2, required: 1.3.0+)
 							;;
 						*)
-							buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libzstd[0-9]*$"
+							buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^libzstd[0-9]*$"
 							buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libzstd-dev"
 							;;
 					esac
@@ -895,7 +895,7 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile tidyhtml-dev"
 				;;
 			tidy@debian)
-				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libtidy5*"
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^libtidy-?[0-9][0-9.\-]*(deb[0-9])?$"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libtidy-dev"
 				;;
 			uuid@alpine)
@@ -936,7 +936,7 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libxslt-dev libgcrypt-dev"
 				;;
 			xsl@debian)
-				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libxslt1.1"
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^libxslt1\.1$"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libxslt-dev"
 				;;
 			yaml@alpine)
@@ -959,14 +959,14 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile cmake gnutls-dev libzip-dev $buildRequiredPackageLists_libssldev zlib-dev"
 				;;
 			zip@debian)
-				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libzip[0-9]$"
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^libzip[0-9]$"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile cmake gnutls-dev $buildRequiredPackageLists_libssldev libzip-dev libbz2-dev zlib1g-dev"
 				case "$DISTRO_VERSION" in
 					debian@8)
 						# Debian Jessie doesn't seem to provide libmbedtls
 						;;
 					*)
-						buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libmbedtls[0-9]*$"
+						buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^libmbedtls[0-9]*$"
 						buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libmbedtls-dev"
 						;;
 				esac


### PR DESCRIPTION
From the `apt-get` manpage:

>  If no package matches the given expression and the expression contains one of '.', '?'
> or '*' then it is assumed to be a POSIX regular expression, and it is applied to all
> package names in the database. Any matches are then installed (or removed). Note that
> matching is done by substring so 'lo.*' matches 'how-lo' and 'lowest'. If this is
> undesired, anchor the regular expression with a '^' or '$' character, or create a more
> specific regular expression.
