### PR TITLE
Remove sync call from README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ FROM php:7.2-cli
 
 ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
-RUN chmod +x /usr/local/bin/install-php-extensions && sync && \
+RUN chmod +x /usr/local/bin/install-php-extensions && \
     install-php-extensions gd xdebug
 ```
 


### PR DESCRIPTION
This `sync` call seems unnecessary.