### PR TITLE
Tensor is not supported on Alpine 3.15

### DIFF
--- a/data/special-requirements
+++ b/data/special-requirements
@@ -2,4 +2,5 @@ parallel zts
 pdo_sqlsrv !alpine3.7 !alpine3.8 !bullseye
 pthreads zts
 sqlsrv !alpine3.7 !alpine3.8 !7.1-alpine3.9 !7.1-alpine3.10 !bullseye
+tensor !alpine3.15
 vips !alpine3.7 !alpine3.8 !alpine3.9 !jessie


### PR DESCRIPTION
Building tensor requires both lapack-dev and openblas-dev
But Alpine maintainers made them incompatible
See https://gitlab.alpinelinux.org/alpine/aports/-/issues/10739
