### PR TITLE
Add libldap-common to debian dependencies

### DIFF
--- a/install-php-extensions
+++ b/install-php-extensions
@@ -710,6 +710,7 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile openldap-dev"
 				;;
 			ldap@debian)
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libldap-common"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libldap2-dev"
 				;;
 			maxminddb@alpine)

--- a/install-php-extensions
+++ b/install-php-extensions
@@ -710,7 +710,9 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile openldap-dev"
 				;;
 			ldap@debian)
-				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libldap-common"
+				if test $DISTRO_VERSION_NUMBER -ge 9; then
+					buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libldap-common"
+				fi
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libldap2-dev"
 				;;
 			maxminddb@alpine)


### PR DESCRIPTION
This used to be installed implicitly within debian-based docker containers by curl, but as of debian 11 isn't.

This is needed to let secure LDAP work out of the box.

Fixes #474