### PR TITLE
using length instead of count for php < 7.2 compatibility

### DIFF
--- a/install-php-extensions
+++ b/install-php-extensions
@@ -219,11 +219,11 @@ set_error_handler(
 $xpath = new DOMXpath($doc);
 $xpath->registerNamespace('v20', 'http://pear.php.net/dtd/package-2.0');
 $xpath->registerNamespace('v21', 'http://pear.php.net/dtd/package-2.1');
-if ($xpath->query('/v20:package/v20:dependencies')->count() === 1) {
+if ($xpath->query('/v20:package/v20:dependencies')->length === 1) {
 	$ns = 'v20:';
-} elseif ($xpath->query('/v21:package/v21:dependencies')->count() === 1) {
+} elseif ($xpath->query('/v21:package/v21:dependencies')->length === 1) {
 	$ns = 'v21:';
-} elseif ($xpath->query('/package')->count() === 1) {
+} elseif ($xpath->query('/package')->length === 1) {
 	$ns = '';
 } else {
 	fwrite(STDERR, "Unsupported namespace of the XML of package version details\n");


### PR DESCRIPTION
When trying to install extension from archive on PHP older then 7.2 it throws:
`Fatal error: Uncaught Error: Call to undefined method DOMNodeList::count() in Command line code:16`

DOMNodeList::count was introduced in PHP 7.2

This PR is using length property instead for compatibility with PHP older then 7.2