### PR TITLE
automatically set proxy for pear/pecl

### DIFF
--- a/install-php-extensions
+++ b/install-php-extensions
@@ -3688,9 +3688,9 @@ configureInstaller() {
 	fi
 	if test $USE_PICKLE -eq 0; then
 		if test -z "$(pear config-get http_proxy)"; then
-			if test -n "$http_proxy"; then
+			if test -n "${http_proxy:-}"; then
 				pear config-set http_proxy "$http_proxy" || true
-			elif test -n "$HTTP_PROXY"; then
+			elif test -n "${HTTP_PROXY:-}"; then
 				pear config-set http_proxy "$HTTP_PROXY" || true
 			fi
 		fi

--- a/install-php-extensions
+++ b/install-php-extensions
@@ -3687,9 +3687,13 @@ configureInstaller() {
 		done
 	fi
 	if test $USE_PICKLE -eq 0; then
-		test -n "$(pear config-get http_proxy)" || \
-		(test -n "$http_proxy" && pear config-set http_proxy $http_proxy) || \
-		(test -n "$HTTP_PROXY" && pear config-set http_proxy $HTTP_PROXY) || true
+		if test -z "$(pear config-get http_proxy)"; then
+			if test -n "$http_proxy"; then
+				pear config-set http_proxy "$http_proxy" || true
+			elif test -n "$HTTP_PROXY"; then
+				pear config-set http_proxy "$HTTP_PROXY" || true
+			fi
+		fi
 		pecl channel-update pecl.php.net || true
 	fi
 }

--- a/install-php-extensions
+++ b/install-php-extensions
@@ -3687,6 +3687,9 @@ configureInstaller() {
 		done
 	fi
 	if test $USE_PICKLE -eq 0; then
+		test -n "$(pear config-get http_proxy)" || \
+		test -n "$http_proxy" && pear config-set http_proxy $http_proxy || \
+		test -n "$HTTP_PROXY" && pear config-set http_proxy $HTTP_PROXY || true
 		pecl channel-update pecl.php.net || true
 	fi
 }

--- a/install-php-extensions
+++ b/install-php-extensions
@@ -3688,8 +3688,8 @@ configureInstaller() {
 	fi
 	if test $USE_PICKLE -eq 0; then
 		test -n "$(pear config-get http_proxy)" || \
-		test -n "$http_proxy" && pear config-set http_proxy $http_proxy || \
-		test -n "$HTTP_PROXY" && pear config-set http_proxy $HTTP_PROXY || true
+		(test -n "$http_proxy" && pear config-set http_proxy $http_proxy) || \
+		(test -n "$HTTP_PROXY" && pear config-set http_proxy $HTTP_PROXY) || true
 		pecl channel-update pecl.php.net || true
 	fi
 }


### PR DESCRIPTION
As described in #615 we should also ease the use of proxies regardless of the underlying implementation.

This does respect `$http_proxy` or `$HTTP_PROXY` just like pickle / composer did.