### PR TITLE
fix KEYEXPIRED error

### DIFF
--- a/install-php-extensions
+++ b/install-php-extensions
@@ -1763,6 +1763,7 @@ markPreinstalledPackagesAsUsed() {
 #
 # Arguments:
 #   $@: the list of APT/APK packages to be installed
+# the --force-yes argument fix the error E: There are problems and -y was used without --force-yes, https://github.com/mlocati/docker-php-extension-installer/issues/699
 installRequiredPackages() {
 	printf '### INSTALLING REQUIRED PACKAGES ###\n'
 	printf '# Packages to be kept after installation: %s\n' "$PACKAGES_PERSISTENT_NEW"
@@ -1780,7 +1781,7 @@ installRequiredPackages() {
 			done
 			;;
 		debian)
-			DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -qq -y $PACKAGES_PERSISTENT_NEW $PACKAGES_VOLATILE
+			DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -qq -y --force-yes $PACKAGES_PERSISTENT_NEW $PACKAGES_VOLATILE
 			;;
 	esac
 }


### PR DESCRIPTION
https://github.com/mlocati/docker-php-extension-installer/issues/699

A colleague found that adding this line solved the problem:

```RUN sed -i 's/DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -qq -y /DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -qq -y --force-yes /'  /usr/local/bin/install-php-extensions```

Full Dockerfile:

```Dockerfile
ARG PHP_VERSION=5.6.27

FROM php:${PHP_VERSION}-fpm

ARG DEBIAN_FRONTEND=noninteractive

COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/

RUN sed -i 's/DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -qq -y /DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -qq -y --force-yes /'  /usr/local/bin/install-php-extensions # this line

RUN install-php-extensions gd xdebug memcached bcmath calendar ftp gettext iconv mcrypt simplexml sockets soap ctype mssql pdo pdo_dblib exif
```