### PR TITLE
feat: add support for predefined processor count

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,7 @@ Here's the list of all the supported environment variables:
 | Extension | Environment variable | Description |
 |---|---|---|
 | | `IPE_DEBUG=1` | By setting this environment variable, the script will print all the commands it executes (it will be very verbose, useful only for debug purposes) |
+| | `IPE_PROCESSOR_COUNT` | Set this environment variable to override the number of processors detected by the script (used for parallel compilation) |
 | | `IPE_DONT_ENABLE=1` | By default the script will install and enable the extensions.<br />If you want to only install them (without enabling them) you can set this environment variable.<br />To enable the extensions at a later time you can execute the command `docker-php-ext-enable-<extension>` (for example: `docker-php-ext-enable-xdebug`).<br />**Beware**: installing some PHP extensions require that other PHP extensions are already enabled, so use this feature wisely. |
 | | `IPE_KEEP_SYSPKG_CACHE=1` | By default the script will clear the apt/apk/pear cache in order to save disk space. You can disable it by setting this environment variable |
 | lzf | `IPE_LZF_BETTERCOMPRESSION=1` | By default `install-php-extensions` compiles the `lzf` extension to prefer speed over size; you can use this environment variable to compile it preferring size over speed |

--- a/install-php-extensions
+++ b/install-php-extensions
@@ -1624,10 +1624,10 @@ expandInstalledSystemPackageName() {
 # Output:
 #   The number of processor cores available
 getProcessorCount() {
-        if test -n "${IPE_PROCESSOR_COUNT:-}"; then
-                echo $IPE_PROCESSOR_COUNT
-                return
-        fi
+	if test -n "${IPE_PROCESSOR_COUNT:-}"; then
+		echo $IPE_PROCESSOR_COUNT
+		return
+	fi
 	if command -v nproc >/dev/null 2>&1; then
 		nproc
 	else

--- a/install-php-extensions
+++ b/install-php-extensions
@@ -1624,6 +1624,10 @@ expandInstalledSystemPackageName() {
 # Output:
 #   The number of processor cores available
 getProcessorCount() {
+        if test -n "${IPE_PROCESSOR_COUNT:-}"; then
+                echo $IPE_PROCESSOR_COUNT
+                return
+        fi
 	if command -v nproc >/dev/null 2>&1; then
 		nproc
 	else


### PR DESCRIPTION
This helps in situations when `nproc` or other automatic ways gives wrong number of available CPU count.