### PR TITLE
Label `org.opencontainers.image.source`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM bash AS build
 
+LABEL org.opencontainers.image.source="https://github.com/mlocati/docker-php-extension-installer"
+
 COPY install-php-extensions /tmp/install-php-extensions
 RUN chmod +x /tmp/install-php-extensions
 


### PR DESCRIPTION
This should improve compatibility with renovate (dependency updates), and maybe other things :)

Renovate would like source URL + release notes when updating the docker tag in a PR.

See https://github.com/renovatebot/renovate/discussions/26286#discussioncomment-7851042 and  https://docs.renovatebot.com/modules/datasource/docker/