### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You may want to run `docker pull mlocati/php-extension-installer` in order to us
 ### Using the script of a Docker image
 
 ```Dockerfile
-RUN  --mount=type=bind,from=mlocati/php-extension-installer:1.5,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \
+RUN  --mount=type=bind,from=mlocati/php-extension-installer:latest,source=/usr/bin/install-php-extensions,target=/usr/local/bin/install-php-extensions \
       install-php-extensions gd xdebug
 ```
 


### PR DESCRIPTION
I'm offering this PR in which I updated the README to use the latest version of the mlocati/php-extension-installer Docker image in the bind-mount example. This is pinned to the 1.5 version. I think there's no reason to use any version but the latest (the other examples sort of do that as well). People copying this line (myself included 😉) would be pinned to an older version and miss out on all the 2.x goodness, so I figured I'd offer a PR that changes the example from using the `1.5` tag to the `latest` tag.

Love this tool, by the way, it saves me quite a bit of headaches!