### PR TITLE
Use GitHub mirror instead of VideoLAN's for reliability.

### DIFF
--- a/install-php-extensions
+++ b/install-php-extensions
@@ -2139,7 +2139,7 @@ isLibdav1dInstalled() {
 # Install libdav1d
 installLibdav1d() {
 	printf 'Installing libdav1d\n'
-	installLibdav1d_dir="$(getPackageSource https://code.videolan.org/videolan/dav1d/-/archive/0.9.2/dav1d-0.9.2.tar.gz)"
+	installLibdav1d_dir="$(getPackageSource https://github.com/videolan/dav1d/archive/refs/tags/0.9.2.tar.gz)"
 	mkdir -- "$installLibdav1d_dir/build"
 	cd -- "$installLibdav1d_dir/build"
 	meson --buildtype release -Dprefix=/usr ..


### PR DESCRIPTION
VideoLAN's website sometimes comes down at the most inopportune of times and stays down for an unspecified duration. To prevent this from causing errors in build pipelines, I propose we shift it to a much more reliable mirror. Since we don't really rely on latest, this should be fine even if updates on it may lag.