### PR TITLE
Support for saxon extension php 7 and 8 and removed early exit 

### DIFF
--- a/install-php-extensions
+++ b/install-php-extensions
@@ -3546,7 +3546,6 @@ installRemoteModule() {
 				ldconfig || true
 			fi
 			cd "$installRemoteModule_dir/Saxon.C.API"
-			exit
 			phpize
 			./configure --enable-saxon
 			make -j$(getProcessorCount) install

--- a/install-php-extensions
+++ b/install-php-extensions
@@ -3520,7 +3520,7 @@ installRemoteModule() {
 				if test $PHP_MAJMIN_VERSION -le 506; then
 					installRemoteModule_version='11.6'
 				else
-					installRemoteModule_version='12.3'
+					installRemoteModule_version='12.4.2'
 				fi
 			fi
 			installRemoteModule_majorVersion="${installRemoteModule_version%%.*}"

--- a/install-php-extensions
+++ b/install-php-extensions
@@ -3519,6 +3519,8 @@ installRemoteModule() {
 			if test -z "$installRemoteModule_version"; then
 				if test $PHP_MAJMIN_VERSION -le 506; then
 					installRemoteModule_version='11.6'
+                                elif test $PHP_MAJMIN_VERSION -le 800; then
+					installRemoteModule_version='12.3'
 				else
 					installRemoteModule_version='12.4.2'
 				fi

--- a/install-php-extensions
+++ b/install-php-extensions
@@ -3519,7 +3519,7 @@ installRemoteModule() {
 			if test -z "$installRemoteModule_version"; then
 				if test $PHP_MAJMIN_VERSION -le 506; then
 					installRemoteModule_version='11.6'
-                                elif test $PHP_MAJMIN_VERSION -le 800; then
+				elif test $PHP_MAJMIN_VERSION -le 800; then
 					installRemoteModule_version='12.3'
 				else
 					installRemoteModule_version='12.4.2'


### PR DESCRIPTION
Fixes #887 by updating to the latest saxon library version `12.4.2` for php8 and removed the early exit.

Verified this with this `Dockerfile`


```Dockerfile
ARG VERSION
FROM php:$VERSION-cli

ADD     https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/

# I patched the `install-php-extensions` here using a diff-patch

RUN     chmod +x /usr/local/bin/install-php-extensions \
        && install-php-extensions saxon
```

And this test script

```bash
#!/usr/bin/env bash
VERSIONS=(7.2 7.3 7.4 8.0 8.1 8.2 8.3)
for v in ${VERSIONS[@]};
do 
  docker build --build-arg VERSION=$v .
done
```

They all completed their build without any issue