### PR TITLE
Docs: Dockerfile: Updated the ADD statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,9 @@ Here's a list of sample `Dockerfile`s that install the GD and xdebug PHP extensi
 ```Dockerfile
 FROM php:7.2-cli
 
-ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
-RUN chmod +x /usr/local/bin/install-php-extensions && \
-    install-php-extensions gd xdebug
+RUN install-php-extensions gd xdebug
 ```
 
 ### Downloading the script on the fly with `curl`


### PR DESCRIPTION
Hello fellow devs. Just a small contribution.

The ADD statement in Dockerfiles now supports both chown and chmod flags.
This makes images less polluted and less repetitive. DRY to the win. :)

As this was merged a long time ago in Moby, backwards compatibility isn't likely to be an issue.
https://github.com/moby/moby/pull/34263

Docs:
https://docs.docker.com/engine/reference/builder/#add

