### PR TITLE
Only install libssl if it exists in apk info

### DIFF
--- a/install-php-extensions
+++ b/install-php-extensions
@@ -678,7 +678,7 @@ buildRequiredPackageLists() {
 			if test $# -gt 1 || test "${1:-}" != '@composer'; then
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS"
 			fi
-			if test -z "$(apk info 2>/dev/null | grep -E ^libssl)"; then
+			if test -n "$(apk info 2>/dev/null | grep -E ^libssl)"; then
 				buildRequiredPackageLists_libssl='^libssl[0-9]+(\.[0-9]+)*$'
 			elif test -z "$(apk info 2>/dev/null | grep -E '^libressl.*-libtls')" && test -z "$(apk info 2>/dev/null | grep -E '^libressl.*-libssl')" && test -z "$(apk info 2>/dev/null | grep -E '^libretls-')"; then
 				buildRequiredPackageLists_libssl=$(apk search -q libressl*-libtls)


### PR DESCRIPTION
When trying to use the script in PHP 5.6 FPM Alpine, it broke trying to install `^libssl[0-9]+(\.[0-9]+)*$`

After closer inspection, it seems that the check:

```bash
#.....
if test -z "$(apk info 2>/dev/null | grep -E ^libssl)"; then
	buildRequiredPackageLists_libssl='^libssl[0-9]+(\.[0-9]+)*$'
elif
#.......
```

is wrong, as it is checking if the resulting string is empty, meaning `apk list` does not have a libssl package, making it impossible to install.