### PR TITLE
Fix SourceGuardian 15 installation on Alpine Linux

### DIFF
--- a/install-php-extensions
+++ b/install-php-extensions
@@ -1314,6 +1314,9 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libcurl3-gnutls"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libcurl4-gnutls-dev libxml2-dev"
 				;;
+			sourceguardian@alpine)
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent eudev-dev"
+				;;
 			spx@alpine)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile zlib-dev"
 				;;

--- a/install-php-extensions
+++ b/install-php-extensions
@@ -1315,7 +1315,7 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libcurl4-gnutls-dev libxml2-dev"
 				;;
 			sourceguardian@alpine)
-				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent eudev-dev"
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent eudev-libs"
 				;;
 			spx@alpine)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile zlib-dev"


### PR DESCRIPTION
SourceGuardian loader 15 now relies on `libudev`.

<details>
  <summary>Error message</summary>

```text
### INSTALLING REMOTE MODULE sourceguardian ###
Downloading SourceGuardian... done (version: 15.0.0)
Removing symbols from /usr/local/lib/php/extensions/no-debug-zts-20220829/sourceguardian.so... done (16776 bytes saved).
Check if the sourceguardian module can be loaded... Error loading the "sourceguardian" extension:

Warning: Failed loading Zend extension 'sourceguardian.so' (tried: /usr/local/lib/php/extensions/no-debug-zts-20220829/sourceguardian.so (Error loading shared library libudev.so.1: No such file or directory (needed by /usr/local/lib/php/extensions/no-debug-zts-20220829/sourceguardian.so)), /usr/local/lib/php/extensions/no-debug-zts-20220829/sourceguardian.so.so (Error loading shared library /usr/local/lib/php/extensions/no-debug-zts-20220829/sourceguardian.so.so: No such file or directory)) in Unknown on line 0
```

</details>

Recreation steps:

```bash
docker run --rm -it --entrypoint=/bin/sh dunglas/frankenphp:latest-php8.2-alpine
# in container
install-php-extensions sourceguardian
  # results in above error message
```

Showcase of the fix:

```bash
docker run --rm -it --entrypoint=/bin/sh dunglas/frankenphp:latest-php8.2-alpine
# in container
curl -sSLf -o /usr/local/bin/install-php-extensions https://raw.githubusercontent.com/justusbunsi/docker-php-extension-installer/sourceguardian15-alpine/install-php-extensions
chmod +x /usr/local/bin/install-php-extensions
install-php-extensions sourceguardian
php -m
  # [Zend Modules]
  # SourceGuardian
```

---

Debian-based images seem fine.