### PR TITLE
Use multi-arch building to have arm64 and amd64 images on docker hub

### DIFF
--- a/.github/workflows/readme-release.yml
+++ b/.github/workflows/readme-release.yml
@@ -170,19 +170,22 @@ jobs:
           username: mlocati
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
-        name: Build docker image
-        if: env.VERSIONTAG_THIS != ''
-        run: >
-          docker build
-          --tag "mlocati/php-extension-installer:$VERSIONTAG_THIS"
-          --tag "mlocati/php-extension-installer:${VERSIONTAG_THIS%.*}"
-          --tag "mlocati/php-extension-installer:${VERSIONTAG_THIS%%.*}"
-          --tag mlocati/php-extension-installer:latest
-          .
+        name: Set up docker buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          install: true
       -
-        name: Push docker image to Docker Hub
+        name: Build and push docker image
         if: env.VERSIONTAG_THIS != ''
-        run: docker push --all-tags mlocati/php-extension-installer
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: |
+            mlocati/php-extension-installer:$VERSIONTAG_THIS
+            mlocati/php-extension-installer:${VERSIONTAG_THIS%.*}
+            mlocati/php-extension-installer:${VERSIONTAG_THIS%%.*}
+            mlocati/php-extension-installer:latest
+          platforms: linux/amd64,linux/arm64
       -
         name: Create release
         if: env.VERSIONTAG_THIS != ''


### PR DESCRIPTION
In order to build a multi arch image (arm64 and amd64) on release on docker hub:

- use the buildx action to load the multi-arch capable builder for docker
- use the `build-push-action` to build and push the multi-arch images (its not possible to do "build" and "push" in separate steps anymore, since the multi-arch build with buildx only supports `--push` and not `--load`).

Tested on my own account:  https://hub.docker.com/r/baschny/php-extension-installer/tags

Resolves  #1005