### PR TITLE
Drop support for PHP 8.0 on Alpine 3.12

### DIFF
--- a/scripts/ci-test-extensions
+++ b/scripts/ci-test-extensions
@@ -23,7 +23,7 @@ set -o nounset
 # $2: the PHP version
 shouldProcessPhpVersionForDistro() {
 	case "$2@$1" in
-		8.1@alpine3.12 | 8.3@buster)
+		8.0@alpine3.12 | 8.1@alpine3.12 | 8.3@buster)
 			return 1
 			;;
 		*)


### PR DESCRIPTION
The Alpine 3.12 version of PHP 8.0 comes with a rather old PHP (8.0.7).

We still have PHP 8.0 on Alpine 3.13, 3.14, 3.15, and 3.16