### PR TITLE
Add flag to compile Swoole 6.x without io_uring support

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,10 +449,7 @@ Here's the list of all the supported environment variables:
 | newrelic | `IPE_NEWRELIC_DAEMON=1` | Install the NewRelic daemon  |
 | newrelic | `IPE_NEWRELIC_KEEPLOG=1` | Keep the log files of NewRelic setup (`/tmp/nrinstall-….tar`)  |
 | newrelic | `NR_INSTALL_KEY` | Your New Relic license key |
-| swoole | `IPE_SWOOLE_WITHOUT_IOURING=1` | The io_uring kernel functionality is considered unsafe by security experts [1][2]; By default Swoole 6 and later is configured with io_uring support, use this environment variable to skip io_uring |
-
-[1](https://security.googleblog.com/2023/06/learnings-from-kctf-vrps-42-linux.html)
-[2](https://i.blackhat.com/BH-US-23/Presentations/US-23-Lin-bad_io_uring.pdf)
+| swoole | `IPE_SWOOLE_WITHOUT_IOURING=1` | The io_uring kernel functionality is considered unsafe by security experts (see [here](https://security.googleblog.com/2023/06/learnings-from-kctf-vrps-42-linux.html) and [here](https://i.blackhat.com/BH-US-23/Presentations/US-23-Lin-bad_io_uring.pdf)). By default Swoole 6 and later is configured with io_uring support, use this environment variable to skip configuring io_uring |
 
 ## Special requirements
 

--- a/README.md
+++ b/README.md
@@ -449,6 +449,10 @@ Here's the list of all the supported environment variables:
 | newrelic | `IPE_NEWRELIC_DAEMON=1` | Install the NewRelic daemon  |
 | newrelic | `IPE_NEWRELIC_KEEPLOG=1` | Keep the log files of NewRelic setup (`/tmp/nrinstall-….tar`)  |
 | newrelic | `NR_INSTALL_KEY` | Your New Relic license key |
+| swoole | `IPE_SWOOLE_WITHOUT_IOURING=1` | The io_uring kernel functionality is considered unsafe by security experts [1][2]; By default Swoole 6 and later is configured with io_uring support, use this environment variable to skip io_uring |
+
+[1](https://security.googleblog.com/2023/06/learnings-from-kctf-vrps-42-linux.html)
+[2](https://i.blackhat.com/BH-US-23/Presentations/US-23-Lin-bad_io_uring.pdf)
 
 ## Special requirements
 

--- a/install-php-extensions
+++ b/install-php-extensions
@@ -1435,12 +1435,17 @@ buildRequiredPackageLists() {
 						buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile sqlite-dev zstd-dev"
 					fi
 				fi
-				# iouring support in swoole 6 requires liburing 2.5+: available since Alpine 3.19
-				# but with Alpine 3.19 we have a "invalid use of incomplete type 'const struct statx'" error
-				if test $DISTRO_MAJMIN_VERSION -ge 320; then
-					buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent liburing"
-					buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile liburing-dev"
-				fi
+				case "${IPE_SWOOLE_WITHOUT_IOURING:-}" in
+					1 | y* | Y*) ;;
+					*)
+					# iouring support in swoole 6 requires liburing 2.5+: available since Alpine 3.19
+					# but with Alpine 3.19 we have a "invalid use of incomplete type 'const struct statx'" error
+					if test $DISTRO_MAJMIN_VERSION -ge 320; then
+						buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent liburing"
+						buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile liburing-dev"
+					fi
+					;;
+				esac
 				;;
 			swoole@debian)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libcurl3-gnutls libpq5"
@@ -4099,21 +4104,31 @@ installRemoteModule() {
 						# we need sqlite3 >= 3.7.7
 						installRemoteModule_sqlite=no
 					fi
-					# iouring support in swoole 6 requires liburing 2.5+: available since Alpine 3.19
-					# but with Alpine 3.19 we have a "invalid use of incomplete type 'const struct statx'" error
-					if test $DISTRO_MAJMIN_VERSION -ge 320; then
-						installRemoteModule_iouring=yes
-					fi
+					case "${IPE_SWOOLE_WITHOUT_IOURING:-}" in
+						1 | y* | Y*) ;;
+						*)
+							# iouring support in swoole 6 requires liburing 2.5+: available since Alpine 3.19
+							# but with Alpine 3.19 we have a "invalid use of incomplete type 'const struct statx'" error
+							if test $DISTRO_MAJMIN_VERSION -ge 320; then
+								installRemoteModule_iouring=yes
+							fi
+							;;
+					esac
 					;;
 				debian)
 					if test $DISTRO_MAJMIN_VERSION -lt 1200; then
 						# we need sqlite3 >= 3.7.7
 						installRemoteModule_sqlite=no
 					fi
-					if test $DISTRO_VERSION_NUMBER -ge 13; then
-						# iouring support in swoole 6 requires liburing 2.5+: available since Debian Trixie (13)
-						installRemoteModule_iouring=yes
-					fi
+					case "${IPE_SWOOLE_WITHOUT_IOURING:-}" in
+						1 | y* | Y*) ;;
+						*)
+							if test $DISTRO_VERSION_NUMBER -ge 13; then
+								# iouring support in swoole 6 requires liburing 2.5+: available since Debian Trixie (13)
+								installRemoteModule_iouring=yes
+							fi
+							;;
+					esac
 					;;
 			esac
 			installRemoteModule_zstd=yes

--- a/install-php-extensions
+++ b/install-php-extensions
@@ -1438,13 +1438,13 @@ buildRequiredPackageLists() {
 				case "${IPE_SWOOLE_WITHOUT_IOURING:-}" in
 					1 | y* | Y*) ;;
 					*)
-					# iouring support in swoole 6 requires liburing 2.5+: available since Alpine 3.19
-					# but with Alpine 3.19 we have a "invalid use of incomplete type 'const struct statx'" error
-					if test $DISTRO_MAJMIN_VERSION -ge 320; then
-						buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent liburing"
-						buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile liburing-dev"
-					fi
-					;;
+						# iouring support in swoole 6 requires liburing 2.5+: available since Alpine 3.19
+						# but with Alpine 3.19 we have a "invalid use of incomplete type 'const struct statx'" error
+						if test $DISTRO_MAJMIN_VERSION -ge 320; then
+							buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent liburing"
+							buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile liburing-dev"
+						fi
+						;;
 				esac
 				;;
 			swoole@debian)


### PR DESCRIPTION
This PR adds a flag to optionally compile Swoole without enabling io_uring support.

(I am not sure if this is the best way to implement this in the script)

Security experts generally believe io_uring to be unsafe. In fact Google ChromeOS and Android have turned it off, plus all Google production servers turn it off. Based on the blog published by Google below it seems like a bunch of vulnerabilities related to io_uring can be exploited to breakout of the container. [Google Security Blog]
Other security reaserchers also hold this opinion: see the [Blackhat Presentation] on io_uring exploits.

Impact on IPE:
Secure defaults on many container runtimes and operating systems limit `io_uring` syscalls to privileged users holding `CAP_SYS_ADMIN`. If Swoole is compiled with io_uring support enabled, and the resulting container is run as a non-privileged/non-root user with these secure defaults, the installation will crash with an io_uring permissions error when using any filesystem function hooked by Swoole in a Coroutine.

There does not appear to be a mechanism to disable this behavior at Swoole runtime.

[Google Security Blog]: https://security.googleblog.com/2023/06/learnings-from-kctf-vrps-42-linux.html
[Blackhat Presentation]: https://i.blackhat.com/BH-US-23/Presentations/US-23-Lin-bad_io_uring.pdf