### PR TITLE
Enable Swoole curl-native on Alpine

### DIFF
--- a/install-php-extensions
+++ b/install-php-extensions
@@ -4109,12 +4109,6 @@ installRemoteModule() {
 					fi
 					;;
 			esac
-			if test $PHP_MAJMIN_VERSION -ge 800; then
-				# see https://github.com/swoole/swoole-src/issues/5365
-				installRemoteModule_curl=no
-			else
-				installRemoteModule_curl=yes
-			fi
 			if test $PHP_THREADSAFE -eq 1; then
 				installRemoteModule_zts=yes
 			else
@@ -4124,6 +4118,7 @@ installRemoteModule() {
 			installRemoteModule_iouring=no
 			case "$DISTRO" in
 				alpine)
+					installRemoteModule_curl=yes
 					if test $DISTRO_MAJMIN_VERSION -lt 317; then
 						# we need sqlite3 >= 3.7.7
 						installRemoteModule_sqlite=no
@@ -4140,6 +4135,12 @@ installRemoteModule() {
 					esac
 					;;
 				debian)
+					if test $PHP_MAJMIN_VERSION -ge 800; then
+						# see https://github.com/swoole/swoole-src/issues/5365
+						installRemoteModule_curl=no
+					else
+						installRemoteModule_curl=yes
+					fi
 					if test $DISTRO_MAJMIN_VERSION -lt 1200; then
 						# we need sqlite3 >= 3.7.7
 						installRemoteModule_sqlite=no

--- a/install-php-extensions
+++ b/install-php-extensions
@@ -4116,9 +4116,9 @@ installRemoteModule() {
 			fi
 			installRemoteModule_sqlite=yes
 			installRemoteModule_iouring=no
+			installRemoteModule_curl=yes
 			case "$DISTRO" in
 				alpine)
-					installRemoteModule_curl=yes
 					if test $DISTRO_MAJMIN_VERSION -lt 317; then
 						# we need sqlite3 >= 3.7.7
 						installRemoteModule_sqlite=no
@@ -4138,8 +4138,6 @@ installRemoteModule() {
 					if test $PHP_MAJMIN_VERSION -ge 800; then
 						# see https://github.com/swoole/swoole-src/issues/5365
 						installRemoteModule_curl=no
-					else
-						installRemoteModule_curl=yes
 					fi
 					if test $DISTRO_MAJMIN_VERSION -lt 1200; then
 						# we need sqlite3 >= 3.7.7


### PR DESCRIPTION
At minimum Swoole 6 on Alpine doesn't experience the segmentation fault with the native curl implementation, under default installation criteria.

This is the initial attempt at a change, we will want to ensure the test cases for Swoole curl cover this change sufficiently.