### PR TITLE
PHP imagick 8.4.x building issue fix

### DIFF
--- a/install-php-extensions
+++ b/install-php-extensions
@@ -3333,6 +3333,11 @@ installRemoteModule() {
 				fi
 			fi
 			;;
+		imagick)
+			if test $PHP_MAJMIN_VERSION -ge 840; then
+				installRemoteModule_cppflags="-Dphp_strtolower=zend_str_tolower"
+			fi
+			;;
 		imap)
 			# Include Kerberos Support
 			addConfigureOption with-kerberos yes


### PR DESCRIPTION
There's issue when imagick is built for PHP 8.4. 
Base image is `php-8.4-fpm-alpine`
It dies with error:
```
736.7 /tmp/pear/temp/imagick/imagick.c: In function 'php_imagick_read_property':
736.7 /tmp/pear/temp/imagick/imagick.c:606:49: error: implicit declaration of function 'php_strtolower'; did you mean 'php_strtok_r'? [-Wimplicit-function-declaration]
736.7   606 |                                                 php_strtolower(Z_STRVAL_P(retval), Z_STRLEN_P(retval));
736.7       |                                                 ^~~~~~~~~~~~~~
736.7       |                                                 php_strtok_r
736.7 make: *** [Makefile:222: imagick.lo] Error 1
```

Have found fix for this. Please review and accept
Have used scripts/lint