### PR TITLE
Use newer Imagick 3.8.0RC2, with patches for PHP 8.4 and more

### DIFF
--- a/install-php-extensions
+++ b/install-php-extensions
@@ -276,7 +276,7 @@ processPHPModuleArgument() {
 	case "$processPHPModuleArgument_arg" in
 		imagick)
 			if test $PHP_MAJMIN_VERSION -ge 804; then
-				processPHPModuleArgument_arg=imagick/imagick@65e27f2bc02e7e8f1bf64e26e359e42a1331fca1
+				processPHPModuleArgument_arg=imagick/imagick@cec37ecb4e9e2f13d756f93c008b2a287fc592c2
 			elif test $PHP_MAJMIN_VERSION -ge 803; then
 				processPHPModuleArgument_arg=imagick/imagick@28f27044e435a2b203e32675e942eb8de620ee58
 			fi


### PR DESCRIPTION
Hey!

Imagick has released a new version - currently still RC - after a long time. It now also has official PHP 8.4 support. I've been using it for a few days now and it works without any problems.

It is now also included in the official WordPress image:
https://github.com/docker-library/wordpress/blob/89a9728770fd81577a2408254aa007943733152f/latest/php8.4/fpm/Dockerfile#L50C29-L50C74

It would be cool if we had it here too.