### PR TITLE
Fix php-geos extension download URL (#1084)

### DIFF
--- a/install-php-extensions
+++ b/install-php-extensions
@@ -3254,9 +3254,9 @@ installRemoteModule() {
 		geos)
 			if test -z "$installRemoteModule_path"; then
 				if test -z "$installRemoteModule_version"; then
-					installRemoteModule_version=0def35611f773c951432f1f06a155471a5cb7611
+					installRemoteModule_version=dfe1ab17b0f155cc315bc13c75689371676e02e1
 				fi
-				installRemoteModule_src="$(getPackageSource https://git.osgeo.org/gitea/geos/php-geos/archive/$installRemoteModule_version.tar.gz)"
+				installRemoteModule_src="$(getPackageSource https://github.com/libgeos/php-geos/archive/$installRemoteModule_version.tar.gz)"
 				cd "$installRemoteModule_src"
 				./autogen.sh
 				./configure


### PR DESCRIPTION
## 🛠️ What does this PR do?
This PR updates the download URL for the `php-geos` extension to use the GitHub mirror instead of the old git.osgeo.org source, which is no longer available.

## 🔍 Issue Reference
Fixes #1084  

## ✅ Changes Made
- Updated the `php-geos` extension download URL  
- Updated the commit hash for a more recent version  
