### PR TITLE
Distro Stretch: Added flag --allow-unauthenticated to apt-get install inside installRequiredPackages() function

### DIFF
--- a/install-php-extensions
+++ b/install-php-extensions
@@ -2020,10 +2020,10 @@ installRequiredPackages() {
 			;;
 		debian)
 			if test "$DISTRO_VERSION" = debian@8 || test "$DISTRO_VERSION" = debian@9; then
-        			apt-get install -qqy --no-install-recommends --allow-unauthenticated $PACKAGES_PERSISTENT_NEW $PACKAGES_VOLATILE
-                	else
-        			apt-get install -qqy --no-install-recommends $PACKAGES_PERSISTENT_NEW $PACKAGES_VOLATILE
-                	fi
+				apt-get install -qqy --no-install-recommends --allow-unauthenticated $PACKAGES_PERSISTENT_NEW $PACKAGES_VOLATILE
+			else
+				apt-get install -qqy --no-install-recommends $PACKAGES_PERSISTENT_NEW $PACKAGES_VOLATILE
+			fi
 			;;
 	esac
 }

--- a/install-php-extensions
+++ b/install-php-extensions
@@ -2019,7 +2019,11 @@ installRequiredPackages() {
 			done
 			;;
 		debian)
-			apt-get install -qqy --no-install-recommends $PACKAGES_PERSISTENT_NEW $PACKAGES_VOLATILE
+			if test "$DISTRO_VERSION" = debian@8 || test "$DISTRO_VERSION" = debian@9; then
+        			apt-get install -qqy --no-install-recommends --allow-unauthenticated $PACKAGES_PERSISTENT_NEW $PACKAGES_VOLATILE
+                	else
+        			apt-get install -qqy --no-install-recommends $PACKAGES_PERSISTENT_NEW $PACKAGES_VOLATILE
+                	fi
 			;;
 	esac
 }


### PR DESCRIPTION
For archived debian distro Stretch the flag is needed in apt-get install call inside installRequiredPackages() function. Otherwise it fails. 
May be it could be necessary to add the flag in other functions of the srcipt that contains the apt-get install call. But they are for  particular extensions that I didn't use.