### PR TITLE
Allow installing remote extensions instead of bundled ones

### DIFF
--- a/.github/workflows/test-extensions.yml
+++ b/.github/workflows/test-extensions.yml
@@ -167,6 +167,37 @@ jobs:
       -
         run: docker run --rm --volume "$(pwd):/app" --workdir /app php:7.4-alpine ./scripts/test-installcomposer "${{ matrix.composer_version }}"
 
+  test_bundled_vs_remote:
+    name: Test installing remote ${{ matrix.extension-name }} insead of bundled
+    container: php:8.4-cli-alpine
+    needs:
+      - check_syntax_data
+      - check_syntax_shell
+      - check_syntax_php
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          -
+            extension-name: oci8
+            source: php/pecl-database-oci8@7aa1061
+          -
+            extension-name: pdo_oci
+            source: php/pecl-database-pdo_oci@ffd7598
+          -
+            extension-name: zip
+            source: zip-1.22.6
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Install extension
+        run: ./install-php-extensions "${{ matrix.source }}"
+      -
+        name: Inspect extension
+        run: php --ri "${{ matrix.extension-name }}"
+
   test_marking_packages:
     name: Test marking pre-installed packages
     needs:

--- a/README.md
+++ b/README.md
@@ -178,6 +178,31 @@ Accepted formats are:
   tar xzf /tmp/source.tgz -C /tmp
   install-php-extensions /tmp/php-memcached-3.1.5
 
+## Bundled extensions or not?
+
+There are some extensions that are bundled in the PHP source code (for example, `gd` and `zip`).
+
+Some of these extensions are also available on PECL and/or a source code repository.
+
+By default, `install-php-extensions` installs the bundled version.
+
+If instead you want to use a remote version:
+
+- for using PECL: just append the stability to the package name. For example:
+  ```
+  install-php-extensions zip-stable
+  ```
+- for installing from source code: use the syntax [specified above](#installing-an-extension-from-its-source-code). For example:
+  ```
+  install-php-extensions php/pecl-database-oci8@7aa1061
+  ```
+
+`install-php-extensions` supports installing remote versions instead of bundled ones for these extensions:
+
+- pdo_oci
+- oci8
+- zip
+
 ## Installing composer
 
 You can also install [composer](https://getcomposer.org/), and you also can specify a major version of it, or a full version.

--- a/install-php-extensions
+++ b/install-php-extensions
@@ -265,6 +265,9 @@ EOT
 # Set these variables:
 # - PROCESSED_PHP_MODULE_ARGUMENT
 #
+# Update these variables:
+# - FORCED_REMOTE_MODULES
+#
 # Optionally set these variables:
 # - PHP_WANTEDMODULEVERSION_<...> (where <...> is the normalized module name)
 # - PHP_MODULESOURCECODEPATH_<...> (where <...> is the normalized module name)
@@ -319,6 +322,7 @@ processPHPModuleArgument() {
 		PROCESSED_PHP_MODULE_ARGUMENT="$(normalizePHPModuleName "$PROCESSED_PHP_MODULE_ARGUMENT")"
 	fi
 	if test -n "$processPHPModuleArgument_version"; then
+		FORCED_REMOTE_MODULES="${FORCED_REMOTE_MODULES:+$FORCED_REMOTE_MODULES }$PROCESSED_PHP_MODULE_ARGUMENT"
 		if printf '%s' "$PROCESSED_PHP_MODULE_ARGUMENT" | grep -Eq '^[a-zA-Z0-9_]+$'; then
 			eval PHP_WANTEDMODULEVERSION_$PROCESSED_PHP_MODULE_ARGUMENT="$processPHPModuleArgument_version"
 		elif printf '%s' "$PROCESSED_PHP_MODULE_ARGUMENT" | grep -Eq '^@[a-zA-Z0-9_]+$'; then
@@ -497,12 +501,14 @@ setPHPPreinstalledModules() {
 #
 # Set:
 #   PHP_MODULES_TO_INSTALL
+#   FORCED_REMOTE_MODULES
 #
 # Output:
 #   Nothing
 processCommandArguments() {
 	processCommandArguments_endArgs=0
 	PHP_MODULES_TO_INSTALL=''
+	FORCED_REMOTE_MODULES=''
 	# Support deprecated flag IPE_FIX_CACERTS
 	case "${IPE_FIX_CACERTS:-}" in
 		1 | y* | Y*)
@@ -5208,7 +5214,7 @@ for PHP_MODULE_TO_INSTALL in $PHP_MODULES_TO_INSTALL; do
 			installComposer
 			;;
 		*)
-			if stringInList "$PHP_MODULE_TO_INSTALL" "$BUNDLED_MODULES"; then
+			if stringInList "$PHP_MODULE_TO_INSTALL" "$BUNDLED_MODULES" && ! stringInList "$PHP_MODULE_TO_INSTALL" "$FORCED_REMOTE_MODULES"; then
 				installBundledModule "$PHP_MODULE_TO_INSTALL"
 			else
 				installRemoteModule "$PHP_MODULE_TO_INSTALL"


### PR DESCRIPTION
For example:

- ```sh
  install-php-extensions oci8
  ```
  will install the bundled oci8 extension
- ```sh
  install-php-extensions php/pecl-database-oci8@7aa106119c671c9132162b9775e154aeae9ef485
  ```
  will install the oci8 extension downloading it from github

PS: I only tested zip (from PECL), oci8 (from github), pdo_oci (from github)

PPS: Close #1112