### PR TITLE
Since saxon 12.9 archive is named arm64 instead of aarch64

### DIFF
--- a/install-php-extensions
+++ b/install-php-extensions
@@ -4146,19 +4146,23 @@ installRemoteModule() {
 					installRemoteModule_edition=EE
 					;;
 			esac
-			case $(uname -m) in
-				aarch64 | arm64 | armv8)
-					installRemoteModule_architecture=linux-arm64
-					;;
-				*)
-					installRemoteModule_architecture=linux-x86_64
-					;;
-			esac
 			if test -z "$installRemoteModule_version"; then
 				if test $PHP_MAJMIN_VERSION -lt 800; then
 					installRemoteModule_version='12.3'
 				fi
 			fi
+			case $(uname -m) in
+				aarch64 | arm64 | armv8)
+					if test -z "$installRemoteModule_version" || test $(compareVersions "$installRemoteModule_version" '12.9') -ge 0 || test $(compareVersions "$installRemoteModule_version" '12.6') -lt 0; then
+						installRemoteModule_architecture=linux-arm64
+					else
+						installRemoteModule_architecture=linux-aarch64
+					fi
+					;;
+				*)
+					installRemoteModule_architecture=linux-x86_64
+					;;
+			esac
 			installRemoteModule_majorVersion=
 			if test -n "$installRemoteModule_version"; then
 				installRemoteModule_majorVersion="${installRemoteModule_version%%.*}"


### PR DESCRIPTION
12.9:
- https://downloads.saxonica.com/SaxonC/EE/12/SaxonCEE-linux-arm64-12-9-0.zip

12.6-12.8:
- e.g. https://downloads.saxonica.com/SaxonC/EE/12/SaxonCEE-linux-aarch64-12-8-0.zip

Until 12.5:
- e.g. https://downloads.saxonica.com/SaxonC/EE/12/SaxonCEE-linux-arm64-12-9-0.zip

Older versions have sometimes just major.minor.

This PR fixes the installation of the latest version, but is not handling the deviations for the other/older archives.