### PR TITLE
Fixed issue in Alpine package determination

### DIFF
--- a/install-php-extensions
+++ b/install-php-extensions
@@ -1783,8 +1783,8 @@ expandPackagesToBeInstalled() {
 			IFS='
 '
 			for expandPackagesToBeInstalled_line in $expandPackagesToBeInstalled_log; do
-				if test -n "$(printf '%s' "$expandPackagesToBeInstalled_line" | grep -E '^\([0-9]*/[0-9]*) Installing ')"; then
-					expandPackagesToBeInstalled_result="$expandPackagesToBeInstalled_result $(printf '%s' "$expandPackagesToBeInstalled_line" | cut -d ' ' -f 3)"
+				if test -n "$(printf '%s' "$expandPackagesToBeInstalled_line" | grep -E '^\( *[0-9]*/[0-9]*) Installing ')"; then
+					expandPackagesToBeInstalled_result="$expandPackagesToBeInstalled_result $(printf '%s' "$expandPackagesToBeInstalled_line" | sed -E 's/^\(.+\) Installing //' | cut -d ' ' -f 1)"
 				fi
 			done
 			resetIFS


### PR DESCRIPTION
Hi!

I recently ran into an issue where the `ssh2` module would not install in my PHP 8.5 Alpine image. The autoconf package was not present. Adding it to the volatile packages did not help. After some debugging I noticed that due to a regex issue the first 10 packages that would be installed were skipped.

As an example, here's the output of the `apk --no-cache --simulate add libssh2-dev curl python3 autoconf` command:

```
( 1/20) Installing m4 (1.4.20-r0)
( 2/20) Installing libbz2 (1.0.8-r6)
( 3/20) Installing perl (5.42.0-r0)
( 4/20) Installing autoconf (2.72-r1)
( 5/20) Installing libssh2 (1.11.1-r1)
( 6/20) Installing pkgconf (2.5.1-r0)
( 7/20) Installing openssl-dev (3.5.4-r0)
( 8/20) Installing zlib-dev (1.3.1-r2)
( 9/20) Installing libssh2-dev (1.11.1-r1)
(10/20) Installing libexpat (2.7.3-r0)
(11/20) Installing libffi (3.5.2-r0)
(12/20) Installing gdbm (1.26-r0)
(13/20) Installing libgcc (15.2.0-r2)
(14/20) Installing libstdc++ (15.2.0-r2)
(15/20) Installing mpdecimal (4.0.1-r0)
(16/20) Installing libpanelw (6.5_p20251123-r0)
(17/20) Installing python3 (3.12.12-r0)
(18/20) Installing python3-pycache-pyc0 (3.12.12-r0)
(19/20) Installing pyc (3.12.12-r0)
(20/20) Installing python3-pyc (3.12.12-r0)
OK: 105 MiB in 61 packages
```

Notice the leading space for the first 9 packages, this space was not accounted for in the regex. I've added it, but also had to strip the counter, because the space causes issues for the `cut` command. This introduces a dependency on an additional command, `sed`, which should always be present anyway, so I hope this isn't an issue.