### PR TITLE
Fix for the Swoole Firebird on Alpine arm64

### DIFF
--- a/install-php-extensions
+++ b/install-php-extensions
@@ -1513,7 +1513,7 @@ buildRequiredPackageLists() {
 						if test $PHP_MAJMIN_VERSION -ge 802; then
 							buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libssh2"
 							buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile ncurses-dev libssh2-dev"
-							if test $PHP_MAJMIN_VERSION -ge 804; then # swoole 6.2+ requires firebird 3+, but with PHP < 8.4 we install firebird 2.5 (see installFirebird)
+							if test $PHP_MAJMIN_VERSION -ge 804 && test "$TARGET_TRIPLET" != aarch64-alpine-linux-musl; then # firebird 5 currently fails to link on Alpine arm64
 								if ! isFirebirdInstalled; then
 									COMPILE_LIBS="$COMPILE_LIBS firebird"
 									if ! isLibTommathInstalled; then
@@ -4579,7 +4579,7 @@ installRemoteModule() {
 			installRemoteModule_firebird=yes
 			case "$DISTRO" in
 				alpine)
-					if test $PHP_MAJMIN_VERSION -lt 804; then # swoole 6.2+ requires firebird 3+, but with PHP < 8.4 we install firebird 2.5 (see installFirebird)
+					if test $PHP_MAJMIN_VERSION -lt 804 || test "$TARGET_TRIPLET" = aarch64-alpine-linux-musl; then # firebird 5 currently fails to link on Alpine arm64
 						installRemoteModule_firebird=no
 					fi
 					;;


### PR DESCRIPTION
Fix after https://github.com/mlocati/docker-php-extension-installer/pull/1246

We need to disable Firebird support for `swoole` on `aarch64-alpine-linux-musl` as current `install-php-extensions`  pulls in a Firebird 5 source build. When installing `swoole` on:
  - Alpine
  - arm64 / aarch64
  - PHP 8.4+

Firebird build fails during linking with errors like:

```text
undefined reference to `_mcount'
collect2: error: ld returned 1 exit status
```

**A minimal repro is:**
```
FROM php:8.4-cli-alpine
COPY --from=ghcr.io/mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
RUN install-php-extensions swoole
```

As a result, install-php-extensions swoole fails on Alpine arm64 even if Firebird support is not required by the user. 

The fix only affects `swoole + Alpine + arm64/aarch64 musl` combo and keeps Firebird enabled elsewhere.

