### PR TITLE
imagick: install libheif-plugin-aomenc on Debian 13+ for AVIF support

### DIFF
--- a/install-php-extensions
+++ b/install-php-extensions
@@ -1071,7 +1071,7 @@ buildRequiredPackageLists() {
 				;;
 			imagick@debian)
 				if test $DISTRO_VERSION_NUMBER -ge 13; then
-					buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^libmagickwand-7.q16-[0-9]+$ ^libmagickcore-7.q16-[0-9]+-extra$"
+					buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^libmagickwand-7.q16-[0-9]+$ ^libmagickcore-7.q16-[0-9]+-extra$ libheif-plugin-aomenc"
 				else
 					buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^libmagickwand-6.q16-[0-9]+$ ^libmagickcore-6.q16-[0-9]+-extra$"
 				fi


### PR DESCRIPTION
On Debian 13 the `libheif1` codecs were split into separate plugin packages, so `imagick` images no longer include an AV1 encoder and ImageMagick can't write AVIF. This adds `libheif-plugin-aomenc` on Debian 13+; bookworm and Alpine are unaffected afaik.

Test: imagick