### PR TITLE
Add support for Wolfi-based images

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Supported docker images are:
 
 - Debian-based docker images: since jessie (Debian 8) (minimum PHP version: 5.5)
 - Alpine-based docker images: since Alpine 3.9 (minimum PHP version: 7.1)
+- Wolfi-based docker images: rolling-release apk distro by Chainguard (`cgr.dev/...`)
 
 See also the notes in the [Special requirements](#special-requirements) section.
 

--- a/install-php-extensions
+++ b/install-php-extensions
@@ -688,7 +688,7 @@ buildRequiredPackageLists() {
 	buildRequiredPackageLists_volatile=''
 	COMPILE_LIBS=''
 	case "$DISTRO" in
-		alpine)
+		alpine | wolfi)
 			apk update
 			;;
 		debian)
@@ -727,7 +727,7 @@ buildRequiredPackageLists() {
 			;;
 	esac
 	case "$DISTRO_VERSION" in
-		alpine@*)
+		alpine@* | wolfi@*)
 			if test $# -gt 1 || test "${1:-}" != '@composer'; then
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $PHPIZE_DEPS"
 			fi
@@ -798,7 +798,7 @@ buildRequiredPackageLists() {
 			@composer@debian)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent unzip"
 				;;
-			amqp@alpine)
+			amqp@alpine | amqp@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent rabbitmq-c"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile rabbitmq-c-dev"
 				;;
@@ -810,6 +810,10 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libbz2"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile bzip2-dev"
 				;;
+			bz2@wolfi)
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libbz2-1"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile bzip2-dev"
+				;;
 			bz2@debian)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libbz2-dev"
 				;;
@@ -817,13 +821,13 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent cassandra-cpp-driver gmp"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile cassandra-cpp-driver-dev gmp-dev"
 				;;
-			cmark@alpine)
+			cmark@alpine | cmark@wolfi)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile cmake"
 				;;
 			cmark@debian)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile cmake"
 				;;
-			ddtrace@alpine)
+			ddtrace@alpine | ddtrace@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libgcc"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile curl-dev automake libtool"
 				;;
@@ -831,7 +835,7 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent $buildRequiredPackageLists_libssl"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libcurl4-openssl-dev automake libtool"
 				;;
-			dba@alpine)
+			dba@alpine | dba@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent db"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile db-dev"
 				;;
@@ -847,7 +851,7 @@ buildRequiredPackageLists() {
 					buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libmpdec-dev"
 				fi
 				;;
-			ecma_intl@alpine)
+			ecma_intl@alpine | ecma_intl@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent icu-libs $buildRequiredPackageLists_icuPersistent"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile icu-dev libidn-dev"
 				;;
@@ -891,7 +895,7 @@ buildRequiredPackageLists() {
 					buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libenchant-dev"
 				fi
 				;;
-			event@alpine)
+			event@alpine | event@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent $buildRequiredPackageLists_libssl libevent"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $buildRequiredPackageLists_libssldev libevent-dev"
 				;;
@@ -899,14 +903,14 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent $buildRequiredPackageLists_libssl ^libevent[0-9\.\-]*$ ^libevent-openssl[0-9\.\-]*$ ^libevent-extra[0-9\.\-]*$ ^libevent-pthreads[0-9\.\-]*$"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $buildRequiredPackageLists_libssldev libevent-dev"
 				;;
-			ffi@alpine)
+			ffi@alpine | ffi@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libffi"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libffi-dev"
 				;;
 			ffi@debian)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libffi-dev"
 				;;
-			ftp@alpine)
+			ftp@alpine | ftp@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent $buildRequiredPackageLists_libssl"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $buildRequiredPackageLists_libssldev"
 				;;
@@ -920,6 +924,45 @@ buildRequiredPackageLists() {
 				if test $PHP_MAJMIN_VERSION -le 506; then
 					buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libvpx"
 					buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libvpx-dev"
+				else
+					buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libwebp"
+					buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libwebp-dev"
+					if test $PHP_MAJMIN_VERSION -ge 801; then
+						if test $DISTRO_MAJMIN_VERSION -ge 315; then
+							buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libavif aom-libs libdav1d"
+							buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libavif-dev aom-dev dav1d-dev"
+						elif isLibaomInstalled && isLibdav1dInstalled && isLibyuvInstalled && isLibavifInstalled; then
+							buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libstdc++"
+						else
+							case "${IPE_GD_WITHOUTAVIF:-}" in
+								1 | y* | Y*) ;;
+								*)
+									if ! isLibaomInstalled; then
+										COMPILE_LIBS="$COMPILE_LIBS libaom"
+									fi
+									if ! isLibdav1dInstalled; then
+										COMPILE_LIBS="$COMPILE_LIBS libdav1d"
+									fi
+									if ! isLibyuvInstalled; then
+										COMPILE_LIBS="$COMPILE_LIBS libyuv"
+									fi
+									if ! isLibavifInstalled; then
+										COMPILE_LIBS="$COMPILE_LIBS libavif"
+									fi
+									buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libstdc++"
+									buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile cmake nasm meson"
+									;;
+							esac
+						fi
+					fi
+				fi
+				;;
+			gd@wolfi)
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent freetype libjpeg-turbo libpng libxpm"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile freetype-dev libjpeg-turbo-dev libpng-dev libxpm-dev"
+				if test $PHP_MAJMIN_VERSION -le 506; then
+					buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent"
+					buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile"
 				else
 					buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libwebp"
 					buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libwebp-dev"
@@ -989,7 +1032,7 @@ buildRequiredPackageLists() {
 					fi
 				fi
 				;;
-			gearman@alpine)
+			gearman@alpine | gearman@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libstdc++ libuuid"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile boost-dev gperf libmemcached-dev libevent-dev util-linux-dev"
 				;;
@@ -997,7 +1040,7 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^libgearman[0-9]*$"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libgearman-dev"
 				;;
-			geoip@alpine)
+			geoip@alpine | geoip@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent geoip"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile geoip-dev"
 				;;
@@ -1009,6 +1052,10 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent geos-dev"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile geos"
 				;;
+			geos@wolfi)
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent geos-3.14-dev"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile geos-3.14"
+				;;
 			geos@debian)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^libgeos-c1(v[0-9]*)?$"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libgeos-dev"
@@ -1017,7 +1064,11 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libintl"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile gettext-dev"
 				;;
-			gmagick@alpine)
+			gettext@wolfi)
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile gettext-dev"
+				;;
+			gmagick@alpine | gmagick@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent graphicsmagick libgomp"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile graphicsmagick-dev libtool"
 				;;
@@ -1025,14 +1076,14 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^libgraphicsmagick(-q16-)?[0-9]*$"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libgraphicsmagick1-dev"
 				;;
-			gmp@alpine)
+			gmp@alpine | gmp@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent gmp"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile gmp-dev"
 				;;
 			gmp@debian)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libgmp-dev"
 				;;
-			gnupg@alpine)
+			gnupg@alpine | gnupg@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent gpgme"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile gpgme-dev"
 				;;
@@ -1040,14 +1091,14 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^libgpgme[0-9]*$"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile ^libgpgme[0-9]*-dev$"
 				;;
-			grpc@alpine)
+			grpc@alpine | grpc@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libstdc++"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile zlib-dev linux-headers"
 				;;
 			grpc@debian)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile zlib1g-dev"
 				;;
-			http@alpine)
+			http@alpine | http@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libevent"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile zlib-dev curl-dev libevent-dev"
 				if test $PHP_MAJMIN_VERSION -le 506; then
@@ -1073,6 +1124,13 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile imagemagick-dev"
 				if [ $DISTRO_MAJMIN_VERSION -ge 319 ]; then
 					buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ghostscript libheif libjxl libraw librsvg"
+				fi
+				;;
+			imagick@wolfi)
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent imagemagick-7 libgomp"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile imagemagick-7-dev"
+				if [ $DISTRO_MAJMIN_VERSION -ge 319 ]; then
+					buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ghostscript libheif libjxl librsvg"
 				fi
 				;;
 			imagick@debian)
@@ -1106,7 +1164,7 @@ buildRequiredPackageLists() {
 					fi
 				fi
 				;;
-			interbase@alpine)
+			interbase@alpine | interbase@wolfi)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile icu-dev ncurses-dev"
 				if ! isFirebirdInstalled; then
 					COMPILE_LIBS="$COMPILE_LIBS firebird"
@@ -1116,7 +1174,7 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libfbclient2"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile firebird-dev libib-util"
 				;;
-			intl@alpine)
+			intl@alpine | intl@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent icu-libs $buildRequiredPackageLists_icuPersistent"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile icu-dev"
 				if test $DISTRO_MAJMIN_VERSION -ge 322 && test $PHP_MAJMIN_VERSION -eq 801 && test $PHP_MAJMINPAT_VERSION -lt 80133; then
@@ -1127,13 +1185,13 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^libicu[0-9]+$"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libicu-dev"
 				;;
-			ion@alpine)
+			ion@alpine | ion@wolfi)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile cmake git"
 				;;
 			ion@debian)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile cmake git"
 				;;
-			ip2location@alpine)
+			ip2location@alpine | ip2location@wolfi)
 				if ! isLibIP2LocationInstalled; then
 					buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile automake libtool"
 					COMPILE_LIBS="$COMPILE_LIBS libip2location"
@@ -1149,11 +1207,15 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent judy"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile judy-dev"
 				;;
+			judy@wolfi)
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libjudy"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libjudy-dev"
+				;;
 			judy@debian)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libjudydebian1"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libjudy-dev"
 				;;
-			ldap@alpine)
+			ldap@alpine | ldap@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libldap"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile openldap-dev"
 				;;
@@ -1175,11 +1237,15 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent lz4-libs"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile lz4-dev"
 				;;
+			lz4@wolfi)
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent liblz4-1"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile lz4-dev"
+				;;
 			lz4@debian)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent liblz4-1"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile liblz4-dev"
 				;;
-			maxminddb@alpine)
+			maxminddb@alpine | maxminddb@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libmaxminddb"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libmaxminddb-dev"
 				;;
@@ -1191,11 +1257,15 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent judy"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile judy-dev bsd-compat-headers"
 				;;
+			memprof@wolfi)
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libjudy"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libjudy-dev"
+				;;
 			memprof@debian)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libjudydebian1"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libjudy-dev"
 				;;
-			mcrypt@alpine)
+			mcrypt@alpine | mcrypt@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libmcrypt"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libmcrypt-dev"
 				;;
@@ -1203,7 +1273,7 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libmcrypt4"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libmcrypt-dev"
 				;;
-			memcache@alpine)
+			memcache@alpine | memcache@wolfi)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile zlib-dev"
 				;;
 			memcache@debian)
@@ -1211,6 +1281,10 @@ buildRequiredPackageLists() {
 				;;
 			memcached@alpine)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libmemcached-libs"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libmemcached-dev zlib-dev"
+				;;
+			memcached@wolfi)
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libmemcached"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libmemcached-dev zlib-dev"
 				;;
 			memcached@debian)
@@ -1229,6 +1303,10 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent $buildRequiredPackageLists_libssl libsasl"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $buildRequiredPackageLists_libssldev cyrus-sasl-dev"
 				;;
+			mongo@wolfi)
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent $buildRequiredPackageLists_libssl cyrus-sasl-libs"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $buildRequiredPackageLists_libssldev cyrus-sasl-dev"
+				;;
 			mongo@debian)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent $buildRequiredPackageLists_libssl"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $buildRequiredPackageLists_libssldev libsasl2-dev"
@@ -1241,6 +1319,14 @@ buildRequiredPackageLists() {
 					buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile zstd-dev"
 				fi
 				;;
+			mongodb@wolfi)
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent $buildRequiredPackageLists_libssl icu-libs $buildRequiredPackageLists_icuPersistent cyrus-sasl-libs snappy"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $buildRequiredPackageLists_libssldev icu-dev cyrus-sasl-dev snappy-dev zlib-dev"
+				if test $PHP_MAJMIN_VERSION -ge 704; then
+					buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libzstd1"
+					buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile zstd-dev"
+				fi
+				;;
 			mongodb@debian)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent $buildRequiredPackageLists_libssl ^libsnappy[0-9]+(v[0-9]+)?$ ^libicu[0-9]+$"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $buildRequiredPackageLists_libssldev libicu-dev libsasl2-dev libsnappy-dev zlib1g-dev"
@@ -1249,7 +1335,7 @@ buildRequiredPackageLists() {
 					buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libzstd-dev"
 				fi
 				;;
-			mosquitto@alpine)
+			mosquitto@alpine | mosquitto@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent mosquitto-libs"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile mosquitto-dev"
 				;;
@@ -1257,7 +1343,7 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libmosquitto1"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libmosquitto-dev"
 				;;
-			mssql@alpine)
+			mssql@alpine | mssql@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent freetds"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile freetds-dev"
 				;;
@@ -1265,7 +1351,7 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libsybdb5"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile freetds-dev"
 				;;
-			nsq@alpine)
+			nsq@alpine | nsq@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent $buildRequiredPackageLists_libssl libevent"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $buildRequiredPackageLists_libssldev libevent-dev"
 				;;
@@ -1273,7 +1359,7 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent $buildRequiredPackageLists_libssl ^libevent[0-9\.\-]*$"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $buildRequiredPackageLists_libssldev libevent-dev"
 				;;
-			oauth@alpine)
+			oauth@alpine | oauth@wolfi)
 				if test $PHP_MAJMIN_VERSION -ge 700; then
 					buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $buildRequiredPackageLists_libpcredev"
 				fi
@@ -1283,7 +1369,7 @@ buildRequiredPackageLists() {
 					buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $buildRequiredPackageLists_libpcredev"
 				fi
 				;;
-			oci8@alpine | pdo_oci@alpine)
+			oci8@alpine | pdo_oci@alpine | oci8@wolfi | pdo_oci@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libaio libc6-compat libnsl"
 				if test $DISTRO_MAJMIN_VERSION -le 307; then
 					# The unzip tool of Alpine 3.7 can't extract symlinks from ZIP archives: let's use bsdtar instead
@@ -1298,7 +1384,7 @@ buildRequiredPackageLists() {
 				fi
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile unzip"
 				;;
-			odbc@alpine | pdo_odbc@alpine)
+			odbc@alpine | pdo_odbc@alpine | odbc@wolfi | pdo_odbc@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent unixodbc"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile unixodbc-dev"
 				;;
@@ -1314,14 +1400,18 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent $buildRequiredPackageLists_libssl postgresql-libs libstdc++"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $buildRequiredPackageLists_libssldev curl-dev postgresql-dev linux-headers"
 				;;
+			openswoole@wolfi)
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent $buildRequiredPackageLists_libssl libpq-17 libstdc++"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $buildRequiredPackageLists_libssldev curl-dev postgresql-17-dev linux-headers"
+				;;
 			openswoole@debian)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent $buildRequiredPackageLists_libssl libpq5"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $buildRequiredPackageLists_libssldev libcurl4-openssl-dev libpq-dev"
 				;;
-			parle@alpine)
+			parle@alpine | parle@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libstdc++"
 				;;
-			pdo_dblib@alpine)
+			pdo_dblib@alpine | pdo_dblib@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent freetds"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile freetds-dev"
 				;;
@@ -1329,7 +1419,7 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libsybdb5"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile freetds-dev"
 				;;
-			pdo_firebird@alpine)
+			pdo_firebird@alpine | pdo_firebird@wolfi)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile icu-dev ncurses-dev"
 				if ! isFirebirdInstalled; then
 					COMPILE_LIBS="$COMPILE_LIBS firebird"
@@ -1354,16 +1444,24 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent postgresql-libs"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile postgresql-dev"
 				;;
+			pgsql@wolfi | pdo_pgsql@wolfi | pq@wolfi)
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libpq-17"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile postgresql-17-dev"
+				;;
 			pgsql@debian | pdo_pgsql@debian | pq@debian)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libpq5"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libpq-dev"
 				;;
-			php_trie@alpine)
+			php_trie@alpine | php_trie@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libstdc++"
 				;;
 			phpy@alpine)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent python3"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile python3-dev"
+				;;
+			phpy@wolfi)
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent python-3.13"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile python-3.13-dev"
 				;;
 			phpy@debian)
 				if test $DISTRO_VERSION_NUMBER -ge 13; then
@@ -1377,7 +1475,7 @@ buildRequiredPackageLists() {
 				fi
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile python3-dev"
 				;;
-			pkcs11@alpine)
+			pkcs11@alpine | pkcs11@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent softhsm"
 				;;
 			pkcs11@debian)
@@ -1391,7 +1489,7 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libaspell15 $(expandASpellDictionaries)"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libpspell-dev"
 				;;
-			rdkafka@alpine)
+			rdkafka@alpine | rdkafka@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent librdkafka"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile librdkafka-dev"
 				;;
@@ -1424,6 +1522,23 @@ buildRequiredPackageLists() {
 					fi
 				fi
 				;;
+			redis@wolfi)
+				if test $PHP_MAJMIN_VERSION -ge 700; then
+					case "$DISTRO_VERSION" in
+						alpine@3.7)
+							buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent zstd"
+							;;
+						*)
+							buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libzstd1"
+							;;
+					esac
+					buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile zstd-dev"
+					if test $PHP_MAJMIN_VERSION -ge 702; then
+						buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent liblz4-1"
+						buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile lz4-dev"
+					fi
+				fi
+				;;
 			redis@debian)
 				if test $PHP_MAJMIN_VERSION -ge 700; then
 					case "$DISTRO_VERSION" in
@@ -1444,7 +1559,7 @@ buildRequiredPackageLists() {
 					buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile liblz4-dev"
 				fi
 				;;
-			rrd@alpine)
+			rrd@alpine | rrd@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent librrd"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile rrdtool-dev"
 				;;
@@ -1458,19 +1573,25 @@ buildRequiredPackageLists() {
 					buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent $buildRequiredPackageLists_libssl"
 				fi
 				;;
-			saxon@alpine)
+			relay@wolfi)
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent liblz4-1 libzstd1"
+				if test $DISTRO_MAJMIN_VERSION -ge 317; then
+					buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent $buildRequiredPackageLists_libssl"
+				fi
+				;;
+			saxon@alpine | saxon@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libstdc++"
 				;;
 			saxon@debian)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_volatile unzip"
 				;;
-			seasclick@alpine)
+			seasclick@alpine | seasclick@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libstdc++"
 				;;
-			simdjson@alpine)
+			simdjson@alpine | simdjson@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libstdc++"
 				;;
-			smbclient@alpine)
+			smbclient@alpine | smbclient@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libsmbclient"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile samba-dev"
 				;;
@@ -1478,7 +1599,7 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libsmbclient"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libsmbclient-dev"
 				;;
-			snappy@alpine)
+			snappy@alpine | snappy@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent snappy"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile snappy-dev"
 				;;
@@ -1486,7 +1607,7 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^libsnappy1(v[0-9]+)?$"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libsnappy-dev"
 				;;
-			snmp@alpine)
+			snmp@alpine | snmp@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent net-snmp-libs"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile net-snmp-dev"
 				;;
@@ -1494,25 +1615,25 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent snmp"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libsnmp-dev"
 				;;
-			snuffleupagus@alpine)
+			snuffleupagus@alpine | snuffleupagus@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent pcre"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $buildRequiredPackageLists_libpcredev"
 				;;
 			snuffleupagus@debian)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $buildRequiredPackageLists_libpcredev"
 				;;
-			soap@alpine)
+			soap@alpine | soap@wolfi)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libxml2-dev"
 				;;
 			soap@debian)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libxml2-dev"
 				;;
-			sockets@alpine)
+			sockets@alpine | sockets@wolfi)
 				if test $PHP_MAJMIN_VERSION -ge 802; then
 					buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile linux-headers"
 				fi
 				;;
-			sodium@alpine | libsodium@alpine)
+			sodium@alpine | libsodium@alpine | sodium@wolfi | libsodium@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libsodium"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libsodium-dev"
 				;;
@@ -1520,23 +1641,23 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^libsodium[0-9]*$"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libsodium-dev"
 				;;
-			solr@alpine)
+			solr@alpine | solr@wolfi)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile curl-dev libxml2-dev"
 				;;
 			solr@debian)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent $buildRequiredPackageLists_libssl"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libcurl4-openssl-dev libxml2-dev"
 				;;
-			sourceguardian@alpine)
+			sourceguardian@alpine | sourceguardian@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent eudev-libs"
 				;;
-			spx@alpine)
+			spx@alpine | spx@wolfi)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile zlib-dev"
 				;;
 			spx@debian)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile zlib1g-dev"
 				;;
-			sqlsrv@alpine | pdo_sqlsrv@alpine)
+			sqlsrv@alpine | pdo_sqlsrv@alpine | sqlsrv@wolfi | pdo_sqlsrv@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libstdc++ unixodbc"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile unixodbc-dev"
 				;;
@@ -1551,14 +1672,14 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent $buildRequiredPackageLists_libssl libstdc++6 libcurl4"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $buildRequiredPackageLists_libssldev cmake g++ libcurl4-openssl-dev"
 				;;
-			ssh2@alpine)
+			ssh2@alpine | ssh2@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libssh2"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libssh2-dev"
 				;;
 			ssh2@debian)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libssh2-1-dev"
 				;;
-			statgrab@alpine)
+			statgrab@alpine | statgrab@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libstatgrab"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libstatgrab-dev"
 				;;
@@ -1566,7 +1687,7 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^libstatgrab[0-9]*$"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libstatgrab-dev"
 				;;
-			stomp@alpine)
+			stomp@alpine | stomp@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent $buildRequiredPackageLists_libssl"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $buildRequiredPackageLists_libssldev"
 				;;
@@ -1582,6 +1703,45 @@ buildRequiredPackageLists() {
 					buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile c-ares-dev"
 					if test $PHP_MAJMIN_VERSION -ge 801; then
 						buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent zstd-libs"
+						buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile sqlite-dev zstd-dev"
+						if test $PHP_MAJMIN_VERSION -ge 802; then
+							buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libssh2"
+							buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile ncurses-dev libssh2-dev"
+							if test $PHP_MAJMIN_VERSION -ge 804; then # swoole 6.2+ requires firebird 3+, but with PHP < 8.4 we install firebird 2.5 (see installFirebird)
+								if ! isFirebirdInstalled; then
+									COMPILE_LIBS="$COMPILE_LIBS firebird"
+									if ! isLibTommathInstalled; then
+										if ! isLibTomcryptInstalled; then
+											COMPILE_LIBS="$COMPILE_LIBS libtomcrypt"
+										fi
+										COMPILE_LIBS="$COMPILE_LIBS libtommath"
+										buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile cmake"
+									fi
+								fi
+							fi
+						fi
+					fi
+				fi
+				case "${IPE_SWOOLE_WITHOUT_IOURING:-}" in
+					1 | y* | Y*) ;;
+					*)
+						# iouring support in swoole 6 requires liburing 2.5+: available since Alpine 3.19
+						# but with Alpine 3.19 we have a "invalid use of incomplete type 'const struct statx'" error
+						if test $DISTRO_MAJMIN_VERSION -ge 320; then
+							buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent liburing"
+							buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile liburing-dev"
+						fi
+						;;
+				esac
+				;;
+			swoole@wolfi)
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent $buildRequiredPackageLists_libssl libpq-17 libstdc++"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $buildRequiredPackageLists_libssldev curl-dev postgresql-17-dev linux-headers"
+				if test $PHP_MAJMIN_VERSION -ge 702; then
+					buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent c-ares"
+					buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile c-ares-dev"
+					if test $PHP_MAJMIN_VERSION -ge 801; then
+						buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libzstd1"
 						buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile sqlite-dev zstd-dev"
 						if test $PHP_MAJMIN_VERSION -ge 802; then
 							buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libssh2"
@@ -1642,7 +1802,7 @@ buildRequiredPackageLists() {
 					buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile liburing-dev"
 				fi
 				;;
-			sybase_ct@alpine)
+			sybase_ct@alpine | sybase_ct@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent freetds"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile freetds-dev"
 				;;
@@ -1650,7 +1810,7 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libct4"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile freetds-dev"
 				;;
-			tdlib@alpine)
+			tdlib@alpine | tdlib@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent $buildRequiredPackageLists_libssl libstdc++"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $buildRequiredPackageLists_libssldev git cmake gperf zlib-dev linux-headers readline-dev"
 				;;
@@ -1666,6 +1826,24 @@ buildRequiredPackageLists() {
 					if test $DISTRO_MAJMIN_VERSION -le 316; then
 						buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libexecinfo"
 						buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libexecinfo-dev"
+						if test $DISTRO_MAJMIN_VERSION -le 310; then
+							if ! stringInList --force-overwrite "$IPE_APK_FLAGS"; then
+								IPE_APK_FLAGS="$IPE_APK_FLAGS --force-overwrite"
+							fi
+						fi
+					fi
+				else
+					buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent liblapack"
+				fi
+				;;
+			tensor@wolfi)
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent openblas"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile openblas-dev"
+				if test $DISTRO_MAJMIN_VERSION -le 317; then
+					buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent liblapack"
+					if test $DISTRO_MAJMIN_VERSION -le 316; then
+						buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent"
+						buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile"
 						if test $DISTRO_MAJMIN_VERSION -le 310; then
 							if ! stringInList --force-overwrite "$IPE_APK_FLAGS"; then
 								IPE_APK_FLAGS="$IPE_APK_FLAGS --force-overwrite"
@@ -1708,14 +1886,14 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^libtidy-?[0-9][0-9.\-]*(deb[0-9])?$"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libtidy-dev"
 				;;
-			uuid@alpine)
+			uuid@alpine | uuid@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libuuid"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile util-linux-dev"
 				;;
 			uuid@debian)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile uuid-dev"
 				;;
-			uv@alpine)
+			uv@alpine | uv@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libuv"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libuv-dev"
 				;;
@@ -1727,17 +1905,21 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent vips"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile vips-dev"
 				;;
+			vips@wolfi)
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libvips"
+				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libvips-dev"
+				;;
 			vips@debian)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libvips"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libvips-dev"
 				;;
-			wddx@alpine)
+			wddx@alpine | wddx@wolfi)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libxml2-dev"
 				;;
 			wddx@debian)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libxml2-dev"
 				;;
-			wikidiff2@alpine)
+			wikidiff2@alpine | wikidiff2@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libstdc++"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile git"
 				;;
@@ -1745,37 +1927,37 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libthai0"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile git libthai-dev"
 				;;
-			xdebug@alpine)
+			xdebug@alpine | xdebug@wolfi)
 				if test $PHP_MAJMIN_VERSION -ge 800; then
 					buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile linux-headers"
 				fi
 				;;
-			xlswriter@alpine)
+			xlswriter@alpine | xlswriter@wolfi)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile zlib-dev"
 				;;
 			xlswriter@debian)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile zlib1g-dev"
 				;;
-			xmldiff@alpine)
+			xmldiff@alpine | xmldiff@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libstdc++"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libxml2-dev"
 				;;
 			xmldiff@debian)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libxml2-dev"
 				;;
-			xmlrpc@alpine)
+			xmlrpc@alpine | xmlrpc@wolfi)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libxml2-dev"
 				;;
 			xmlrpc@debian)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libxml2-dev"
 				;;
-			xpass@alpine)
+			xpass@alpine | xpass@wolfi)
 				if ! isLibXCryptInstalled; then
 					buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile linux-headers"
 					COMPILE_LIBS="$COMPILE_LIBS libxcrypt"
 				fi
 				;;
-			xsl@alpine)
+			xsl@alpine | xsl@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libxslt"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libxslt-dev libgcrypt-dev"
 				;;
@@ -1783,7 +1965,7 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^libxslt1\.1$"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libxslt-dev"
 				;;
-			yaml@alpine)
+			yaml@alpine | yaml@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent yaml"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile yaml-dev"
 				;;
@@ -1791,14 +1973,14 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libyaml-0-2"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libyaml-dev"
 				;;
-			yar@alpine)
+			yar@alpine | yar@wolfi)
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile curl-dev"
 				;;
 			yar@debian)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent $buildRequiredPackageLists_libssl"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libcurl4-openssl-dev"
 				;;
-			zip@alpine)
+			zip@alpine | zip@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent $buildRequiredPackageLists_libssl libzip"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $buildRequiredPackageLists_libssldev cmake libzip-dev zlib-dev"
 				;;
@@ -1806,7 +1988,7 @@ buildRequiredPackageLists() {
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent $buildRequiredPackageLists_libssl ^libzip[0-9]$"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile $buildRequiredPackageLists_libssldev cmake libzip-dev libbz2-dev zlib1g-dev"
 				;;
-			zmq@alpine)
+			zmq@alpine | zmq@wolfi)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent zeromq-dev"
 				;;
 			zmq@debian)
@@ -1815,6 +1997,11 @@ buildRequiredPackageLists() {
 			zookeeper@alpine)
 				if ! test -f /usr/local/include/zookeeper/zookeeper.h; then
 					buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile maven automake libtool openjdk8"
+				fi
+				;;
+			zookeeper@wolfi)
+				if ! test -f /usr/local/include/zookeeper/zookeeper.h; then
+					buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile maven-3.9 automake libtool openjdk-8-default-jdk"
 				fi
 				;;
 			zookeeper@debian)
@@ -1879,7 +2066,7 @@ buildRequiredPackageLists() {
 expandPackagesToBeInstalled() {
 	expandPackagesToBeInstalled_result=''
 	case "$DISTRO" in
-		alpine)
+		alpine | wolfi)
 			expandPackagesToBeInstalled_log="$(apk add --simulate $@ 2>&1 || printf '\nERROR: apk failed\n')"
 			if test -n "$(printf '%s' "$expandPackagesToBeInstalled_log" | grep -E '^ERROR:')"; then
 				printf 'FAILED TO LIST THE WHOLE PACKAGE LIST FOR\n' >&2
@@ -1942,7 +2129,7 @@ expandInstalledSystemPackageName() {
 		expandInstalledSystemPackageName_grepflags='-E'
 	fi
 	case "$DISTRO" in
-		alpine)
+		alpine | wolfi)
 			apk info | grep $expandInstalledSystemPackageName_grepflags -- "$1" || test $? -eq 1
 			;;
 		debian)
@@ -2167,7 +2354,7 @@ EOT
 markPreinstalledPackagesAsUsed() {
 	printf '### MARKING PRE-INSTALLED PACKAGES AS IN-USE ###\n'
 	case "$DISTRO" in
-		alpine)
+		alpine | wolfi)
 			printf '# Packages: %s\n' "$PACKAGES_PERSISTENT_PRE"
 			apk add $PACKAGES_PERSISTENT_PRE
 			;;
@@ -2192,7 +2379,7 @@ installRequiredPackages() {
 		printf '%s\n' "$PACKAGES_VOLATILE" >"$IPE_SAVE_VOLDEPS_TO"
 	fi
 	case "$DISTRO" in
-		alpine)
+		alpine | wolfi)
 			apk add $IPE_APK_FLAGS $PACKAGES_PERSISTENT_NEW $PACKAGES_VOLATILE
 			# https://gitlab.alpinelinux.org/alpine/aports/-/issues/12763#note_172090
 			# https://github.com/mlocati/docker-php-extension-installer/issues/385
@@ -2223,7 +2410,7 @@ installRequiredPackages() {
 #   1.2.3
 getInstalledPackageVersion() {
 	case "$DISTRO" in
-		alpine)
+		alpine | wolfi)
 			apk info "$1" | head -n1 | cut -c $((${#1} + 2))- | grep -o -E '^[0-9]+(\.[0-9]+){0,2}'
 			;;
 		debian)
@@ -2308,7 +2495,7 @@ installOracleInstantClient() {
 		echo 'done.'
 	fi
 	case "$DISTRO" in
-		alpine)
+		alpine | wolfi)
 			if ! test -e /usr/lib/libresolv.so.2 && test -e /lib/libc.so.6; then
 				ln -s /lib/libc.so.6 /usr/lib/libresolv.so.2
 			fi
@@ -2351,7 +2538,7 @@ isMicrosoftSqlServerODBCInstalled() {
 installMicrosoftSqlServerODBC() {
 	printf 'Installing the Microsoft SQL Server ODBC Driver\n'
 	case "$DISTRO" in
-		alpine)
+		alpine | wolfi)
 			rm -rf /tmp/src/msodbcsql.apk
 			if test $PHP_MAJMIN_VERSION -le 703; then
 				installMicrosoftSqlServerODBC_url=https://download.microsoft.com/download/e/4/e/e4e67866-dffd-428c-aac7-8d28ddafb39b/msodbcsql17_17.10.6.1-1_amd64.apk
@@ -2804,7 +2991,7 @@ installIonCubeLoader() {
 	installIonCubeLoader_soPrefix=ioncube_loader_lin
 	installIonCubeLoader_url='https://downloads.ioncube.com/loader_downloads/ioncube_loaders_lin'
 	case "$DISTRO" in
-		alpine)
+		alpine | wolfi)
 			if test $DISTRO_MAJMIN_VERSION -le 312; then
 				installIonCubeLoader_version=14.0.0 # For 14.4.0 we have a Segmentation Fault
 			fi
@@ -2900,14 +3087,14 @@ installCargo() {
 	if ! test -f "$HOME/.cargo/env"; then
 		printf '# Installing cargo\n'
 		case "$DISTRO" in
-			alpine)
+			alpine | wolfi)
 				# see https://github.com/hyperledger/indy-vdr/issues/69#issuecomment-998104850
 				export RUSTFLAGS='-C target-feature=-crt-static'
 				;;
 		esac
 		curl $IPE_CURL_FLAGS https://sh.rustup.rs -sSf | sh -s -- -y -q
 		case "$DISTRO" in
-			alpine)
+			alpine | wolfi)
 				if test $DISTRO_MAJMIN_VERSION -le 310; then
 					# With version 1.84.0 we have this error:
 					# Error relocating /root/.rustup/toolchains/stable-x86_64-unknown-linux-musl/bin/cargo: posix_spawn_file_actions_addchdir_np: symbol not found
@@ -2946,7 +3133,7 @@ installNewRelic() {
 	fi
 	installNewRelic_search='\bnewrelic-php[0-9.]*-[0-9]+(\.[0-9]+)*-linux'
 	case "$DISTRO" in
-		alpine)
+		alpine | wolfi)
 			installNewRelic_search="$installNewRelic_search-musl"
 			;;
 	esac
@@ -3076,7 +3263,7 @@ EOF
 			else
 				installBundledModule_tmp=0
 				case "$DISTRO" in
-					alpine)
+					alpine | wolfi)
 						if test $DISTRO_MAJMIN_VERSION -ge 315; then
 							installBundledModule_tmp=1
 						fi
@@ -3122,7 +3309,7 @@ EOF
 			;;
 		interbase | pdo_firebird)
 			case "$DISTRO" in
-				alpine)
+				alpine | wolfi)
 					if test $PHP_MAJMIN_VERSION -lt 804; then
 						CFLAGS='-I/tmp/src/firebird/src/jrd -I/tmp/src/firebird/src/include -I/tmp/src/firebird/src/include/gen' docker-php-ext-configure $installBundledModule_module
 					fi
@@ -3131,7 +3318,7 @@ EOF
 			;;
 		intl)
 			case "$DISTRO" in
-				alpine)
+				alpine | wolfi)
 					if test $DISTRO_MAJMIN_VERSION -ge 322 && test $PHP_MAJMIN_VERSION -eq 801 && test $PHP_MAJMINPAT_VERSION -lt 80133; then
 						# See https://github.com/php/php-src/commit/3fdd3ed9f722d9f0aa3122b2340a611db2dfa110
 						docker-php-source extract
@@ -3208,7 +3395,7 @@ EOF
 			;;
 		snmp)
 			case "$DISTRO" in
-				alpine)
+				alpine | wolfi)
 					mkdir -p -m 0755 /var/lib/net-snmp/mib_indexes
 					;;
 			esac
@@ -3227,7 +3414,7 @@ EOF
 			;;
 		tidy)
 			case "$DISTRO" in
-				alpine)
+				alpine | wolfi)
 					if ! test -f /usr/include/buffio.h; then
 						ln -s /usr/include/tidybuffio.h /usr/include/buffio.h
 						UNNEEDED_PACKAGE_LINKS="$UNNEEDED_PACKAGE_LINKS /usr/include/buffio.h"
@@ -3377,7 +3564,7 @@ installRemoteModule() {
 					;;
 			esac
 			case $DISTRO in
-				alpine)
+				alpine | wolfi)
 					installRemoteModule_distro=alpine
 					;;
 				*)
@@ -3433,7 +3620,7 @@ installRemoteModule() {
 				make -s -j$(getProcessorCount) install
 				cd - >/dev/null
 				case "$DISTRO" in
-					alpine)
+					alpine | wolfi)
 						if test -e /usr/local/lib64/libcmark.so.$installRemoteModule_cmarkVersion && ! test -e /usr/local/lib/libcmark.so.$installRemoteModule_cmarkVersion; then
 							ln -s /usr/local/lib64/libcmark.so.$installRemoteModule_cmarkVersion /usr/local/lib/
 						fi
@@ -3458,7 +3645,7 @@ installRemoteModule() {
 				fi
 				if test -z "$installRemoteModule_version"; then
 					case "$DISTRO" in
-						alpine)
+						alpine | wolfi)
 							if test $DISTRO_MAJMIN_VERSION -le 312; then
 								# cc is not supported due to a memcmp related bug
 								installRemoteModule_version=1.1.0
@@ -3475,7 +3662,7 @@ installRemoteModule() {
 			;;
 		decimal)
 			case "$DISTRO" in
-				alpine)
+				alpine | wolfi)
 					if ! test -f /usr/local/lib/libmpdec.so; then
 						installLibMPDec
 					fi
@@ -3583,7 +3770,7 @@ installRemoteModule() {
 		excimer)
 			if test -z "$installRemoteModule_version"; then
 				case "$DISTRO" in
-					alpine)
+					alpine | wolfi)
 						if test $DISTRO_MAJMIN_VERSION -le 313; then
 							# With newer versions we have:
 							# configure: error: excimer requires timer_create or kevent
@@ -3607,7 +3794,7 @@ installRemoteModule() {
 				fi
 			fi
 			case "$DISTRO" in
-				alpine)
+				alpine | wolfi)
 					if ! test -e /usr/local/include/libgearman/gearman.h || ! test -e /usr/local/lib/libgearman.so; then
 						installRemoteModule_src="$(getPackageSource https://github.com/gearman/gearmand/releases/download/1.1.22/gearmand-1.1.22.tar.gz)"
 						cd -- "$installRemoteModule_src"
@@ -4198,7 +4385,7 @@ installRemoteModule() {
 				fi
 				installRemoteModule_version2=''
 				case "$DISTRO" in
-					alpine)
+					alpine | wolfi)
 						installRemoteModule_tmp='librdkafka'
 						;;
 					debian)
@@ -4290,7 +4477,7 @@ installRemoteModule() {
 			installRemoteModule_distro="$DISTRO"
 			installRemoteModule_flags=''
 			case "$DISTRO" in
-				alpine)
+				alpine | wolfi)
 					if test $DISTRO_MAJMIN_VERSION -lt 317; then
 						installRemoteModule_distro=alpine3.9
 					else
@@ -4592,7 +4779,7 @@ installRemoteModule() {
 					installRemoteModule_version="$(resolvePHPModuleVersion "$installRemoteModule_module" '^5.0')"
 				else
 					case "$DISTRO" in
-						alpine)
+						alpine | wolfi)
 							if test $DISTRO_MAJMIN_VERSION -le 312; then
 								installRemoteModule_version=5.1.2
 							elif test $DISTRO_MAJMIN_VERSION -le 315; then
@@ -4629,7 +4816,7 @@ installRemoteModule() {
 			installRemoteModule_iouring=no
 			installRemoteModule_curl=yes
 			case "$DISTRO" in
-				alpine)
+				alpine | wolfi)
 					if test $DISTRO_MAJMIN_VERSION -lt 317; then
 						# we need sqlite3 >= 3.7.7
 						installRemoteModule_sqlite=no
@@ -4681,7 +4868,7 @@ installRemoteModule() {
 			esac
 			installRemoteModule_firebird=yes
 			case "$DISTRO" in
-				alpine)
+				alpine | wolfi)
 					if test $PHP_MAJMIN_VERSION -lt 804; then # swoole 6.2+ requires firebird 3+, but with PHP < 8.4 we install firebird 2.5 (see installFirebird)
 						installRemoteModule_firebird=no
 					fi
@@ -4953,7 +5140,7 @@ installRemoteModule() {
 				fi
 			fi
 			case "$DISTRO" in
-				alpine)
+				alpine | wolfi)
 					if test $DISTRO_MAJMIN_VERSION -ge 315 && test $DISTRO_MAJMIN_VERSION -le 317; then
 						if test -e /usr/lib/liblapacke.so.3 && ! test -e /usr/lib/liblapacke.so; then
 							ln -s /usr/lib/liblapacke.so.3 /usr/lib/liblapacke.so
@@ -4971,7 +5158,7 @@ installRemoteModule() {
 			;;
 		tideways)
 			case "$DISTRO" in
-				alpine)
+				alpine | wolfi)
 					case $(uname -m) in
 						aarch64 | arm64 | armv8)
 							installRemoteModule_architecture=alpine-arm64
@@ -5004,7 +5191,7 @@ installRemoteModule() {
 			fi
 			installRemoteModule_src="$installRemoteModule_src/tideways-php"
 			case "$DISTRO" in
-				alpine)
+				alpine | wolfi)
 					installRemoteModule_src="$installRemoteModule_src-alpine"
 					;;
 			esac
@@ -5077,7 +5264,7 @@ installRemoteModule() {
 			;;
 		wikidiff2)
 			case "$DISTRO" in
-				alpine)
+				alpine | wolfi)
 					if ! isLibDatrieInstalled; then
 						installLibDatrie
 					fi
@@ -5248,7 +5435,7 @@ installRemoteModule() {
 			fi
 			installRemoteModule_version="$(resolvePeclStabilityVersion "$installRemoteModule_module" "$installRemoteModule_version")"
 			case "$DISTRO" in
-				alpine)
+				alpine | wolfi)
 					if ! test -f /usr/local/include/zookeeper/zookeeper.h; then
 						if test $(compareVersions "$installRemoteModule_version" 1.0.0) -lt 0; then
 							installRemoteModule_src="$(getPackageSource http://archive.apache.org/dist/zookeeper/zookeeper-3.5.9/apache-zookeeper-3.5.9.tar.gz)"
@@ -5611,7 +5798,7 @@ cleanup() {
 		done
 	fi
 	case "$DISTRO" in
-		alpine)
+		alpine | wolfi)
 			if stringInList icu-libs "${PACKAGES_PERSISTENT_NEW:-}" && stringInList icu-data-en "${PACKAGES_PERSISTENT_NEW:-}"; then
 				apk del icu-data-en >/dev/null 2>&1 || true
 			fi
@@ -5640,7 +5827,7 @@ cleanup() {
 		1 | y* | Y*) ;;
 		*)
 			case "$DISTRO" in
-				alpine)
+				alpine | wolfi)
 					rm -rf /var/cache/apk/*
 					;;
 				debian)


### PR DESCRIPTION
## Summary

Add support for [Wolfi](https://wolfi.dev) — an apk-based, rolling-release distribution maintained by Chainguard whose container images live under `cgr.dev/...`. Wolfi mostly follows alpine's upstream-source package naming, with a handful of well-known divergences this PR handles explicitly.

## Strategy

For each `EXT@alpine)` block, decide what its wolfi twin should look like:

1. **Shared package names → POSIX `|` alternation.** When alpine and wolfi use the same package names for an extension's deps (~67 of the existing entries: gd, redis, intl, opcache, mbstring, pdo_mysql, …), collapse to:
    ```
    EXT@alpine | EXT@wolfi)
        <shared body>
        ;;
    ```

2. **Different package names → separate `EXT@wolfi)` block with renames.** Wolfi has the same library under a different name for ~15 deps:

    | alpine | wolfi |
    |---|---|
    | `enchant`, `enchant-dev` | `enchant2`, `enchant2-dev` |
    | `geos`, `geos-dev` | `geos-3.14`, `geos-3.14-dev` |
    | `imagemagick`, `imagemagick-dev` | `imagemagick-7`, `imagemagick-7-dev` |
    | `judy`, `judy-dev` | `libjudy`, `libjudy-dev` |
    | `lapack` | `liblapack` |
    | `libbz2` | `libbz2-1` |
    | `libmemcached-libs` | `libmemcached` |
    | `libsasl` | `cyrus-sasl-libs` |
    | `lz4-libs` | `liblz4-1` |
    | `maven` | `maven-3.9` |
    | `openjdk8` | `openjdk-8-default-jdk` |
    | `postgresql-dev`, `postgresql-libs` | `postgresql-17-dev`, `libpq-17` |
    | `python3`, `python3-dev` | `python-3.13`, `python-3.13-dev` |
    | `vips`, `vips-dev` | `libvips`, `libvips-dev` |
    | `zstd-libs` | `libzstd1` |

3. **alpine-musl-only deps → silently dropped from wolfi twin.** `libexecinfo`, `libintl`, `bsd-compat-headers` are needed only on alpine because of musl libc; glibc-based wolfi has equivalents built into libc. `libvpx`/`libvpx-dev` are only used by gd's PHP <= 5.6 path which isn't supported on wolfi anyway.

4. **No wolfi equivalent → no twin emitted.** A few libs simply aren't packaged in wolfi: `aspell-*`, `cassandra-cpp-driver`, `c-client`, `imap-dev`, `lua5.1-*`, `recode`, `tidyhtml`. The corresponding extensions (`pspell`, `cassandra`, `imap`, `luasandbox`, `recode`, `tidy`) remain alpine-only — install-php-extensions will fail on wolfi for those, with the same "package not found" error pattern as any genuinely-missing dep.

`setDistro()` is unchanged — wolfi sets `ID=wolfi` in `/etc/os-release` and the rest of the script's distro-keyed lookups now have wolfi patterns.

## Top-level switches

`case "$DISTRO" in alpine) ...` (apk update, simulate, virtual phpize-deps cleanup) and `case "$DISTRO_VERSION" in alpine@*) ...` (openssl variant, `$PHPIZE_DEPS`, icu-data) use plain alternation — their bodies don't reference per-extension package names.

## Testing

Manually verified end-to-end on a Wolfi-based PHP image:

- `install-php-extensions gd redis` resolves the right deps via apk on Wolfi (using the renamed names where applicable), runs phpize/configure/make against ZTS PHP, produces `/usr/lib/php/modules/{gd,redis}.so` with `tsrm_get_ls_cache` and `tsrm_mutex_*` references (ZTS-compatible).
- `extension=gd` and `extension=redis` registered in `$PHP_INI_DIR/conf.d/`.
- The runtime ZTS interpreter loads both extensions; `imagecreatetruecolor`/`imagepng` produces a valid PNG, and `new Redis()` instantiates correctly.
- Both the bundled-source path (gd) and PECL path (redis) verified.

CI integration is not included in this PR — happy to add a wolfi build matrix entry if you'd like, just want to flag it as a separate question since it'd require deciding which Wolfi base image to test against.

## Out of scope

- No changes to existing alpine/debian behavior — every alpine pattern still matches.
- Extensions whose deps aren't packaged in wolfi (`pspell`, `cassandra`, `imap`, `luasandbox`, `recode`, `tidy`) remain alpine-only.

Filed as a draft to invite feedback on the rename mappings and CI integration approach.