### PR TITLE
Allow installing a specific blackfire version

### DIFF
--- a/install-php-extensions
+++ b/install-php-extensions
@@ -8,7 +8,6 @@
 #
 # License: MIT - see https://github.com/mlocati/docker-php-extension-installer/blob/master/LICENSE
 
-
 # Let's set a sane environment
 set -o errexit
 set -o nounset

--- a/install-php-extensions
+++ b/install-php-extensions
@@ -3385,9 +3385,14 @@ installRemoteModule() {
 					;;
 			esac
 			installRemoteModule_tmp2=$(php -r 'echo PHP_MAJOR_VERSION . PHP_MINOR_VERSION . (ZEND_THREAD_SAFE ? "-zts" : "");')
+			if test -z "$installRemoteModule_version"; then
+				installRemoteModule_url="https://blackfire.io/api/v1/releases/probe/php/$installRemoteModule_distro/$installRemoteModule_tmp1/$installRemoteModule_tmp2"
+			else
+				installRemoteModule_url="https://packages.blackfire.io/binaries/blackfire-php/$installRemoteModule_version/blackfire-php-${installRemoteModule_distro}_${installRemoteModule_tmp1}-php-${installRemoteModule_tmp2}.tar.gz"
+			fi
 			installRemoteModule_tmp="$(mktemp -p /tmp/src -d)"
 			cd "$installRemoteModule_tmp"
-			curl $IPE_CURL_FLAGS -sSLf --user-agent Docker https://blackfire.io/api/v1/releases/probe/php/$installRemoteModule_distro/$installRemoteModule_tmp1/$installRemoteModule_tmp2 | tar xz
+			curl $IPE_CURL_FLAGS -sSLf --user-agent Docker "$installRemoteModule_url" | tar xz
 			mv blackfire-*.so $(getPHPExtensionsDir)/blackfire.so
 			cd - >/dev/null
 			installRemoteModule_manuallyInstalled=1

--- a/install-php-extensions
+++ b/install-php-extensions
@@ -8,6 +8,7 @@
 #
 # License: MIT - see https://github.com/mlocati/docker-php-extension-installer/blob/master/LICENSE
 
+
 # Let's set a sane environment
 set -o errexit
 set -o nounset


### PR DESCRIPTION
Currently, `install-php-extensions blackfire` always fetches the **latest** Blackfire PHP probe from the public API endpoint:

```
https://blackfire.io/api/v1/releases/probe/php/<distro>/<arch>/<phpver>
```

There is no way to pin the installed probe to a specific Blackfire version, which means rebuilding the same Dockerfile at different points in time can yield different probe versions — making builds non-reproducible and breaking environments that need to match a specific Blackfire agent version.

This PR adds support for selecting a specific Blackfire probe version using the standard `install-php-extensions <ext>-<version>` syntax that the script already supports for other extensions, e.g.:

```
install-php-extensions blackfire-1.95.0
```

### Implementation

When a version is supplied, the URL passed to `curl` is switched from the "latest probe" API endpoint to the official versioned tarball hosted on Blackfire's package CDN:

```
https://packages.blackfire.io/binaries/blackfire-php/<version>/blackfire-php-<distro>_<arch>-php-<phpver>.tar.gz
```

Concretely, in the `blackfire)` branch of `installRemoteModule()`:

- A new `installRemoteModule_url` variable is set conditionally:
  - If `installRemoteModule_version` is empty → the existing `blackfire.io/api/v1/releases/probe/php/...` URL (unchanged behavior).
  - Otherwise → the versioned `packages.blackfire.io/binaries/blackfire-php/<version>/...` URL.
- The existing `curl ... | tar xz` invocation now consumes `"$installRemoteModule_url"` instead of the hardcoded API URL.

The existing `$installRemoteModule_distro` (`alpine`/`linux`), `$installRemoteModule_tmp1` (`amd64`/`arm64`/`i386`) and `$installRemoteModule_tmp2` (PHP major+minor, optionally `-zts`) variables are reused for both URL shapes, so architecture, distro and ZTS detection logic is shared between the unversioned and versioned code paths.

### Backwards compatibility

Behavior of `install-php-extensions blackfire` (no version) is unchanged — the same API endpoint is hit and the same probe (latest) is installed. Only the new `blackfire-<version>` form exercises the new code path.