### PR TITLE
Install ddtrace via datadog-setup.php on PHP 7.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,8 @@ Here's the list of all the supported environment variables:
 | newrelic | `IPE_NEWRELIC_DAEMON=1` | Install the NewRelic daemon  |
 | newrelic | `IPE_NEWRELIC_KEEPLOG=1` | Keep the log files of NewRelic setup (`/tmp/nrinstall-….tar`)  |
 | newrelic | `NR_INSTALL_KEY` | Your New Relic license key |
+| ddtrace | `IPE_DD_APPSEC=1` | Also enable the Datadog [Application Security Monitoring](https://docs.datadoghq.com/security/application_security/) module (`ddappsec`). Requires PHP 7.0+ and the 1.x tracer line |
+| ddtrace | `IPE_DD_PROFILING=1` | Also enable the Datadog [Continuous Profiler](https://docs.datadoghq.com/profiler/) module (`datadog-profiling`). Requires PHP 7.1+, Alpine 3.13+ (or any Debian) and the 1.x tracer line |
 | swoole | `IPE_SWOOLE_WITHOUT_IOURING=1` | The io_uring kernel functionality is considered unsafe by security experts (see [here](https://security.googleblog.com/2023/06/learnings-from-kctf-vrps-42-linux.html) and [here](https://i.blackhat.com/BH-US-23/Presentations/US-23-Lin-bad_io_uring.pdf)). By default Swoole 6 and later is configured with io_uring support, use this environment variable to skip configuring io_uring |
 | saxon | `IPE_SAXON_EDITION=EE` | The Saxon edition to be used: `EE` for Enterprise Edition (default), `PE` for Professional Edition, `HE` for Home Edition |
 

--- a/install-php-extensions
+++ b/install-php-extensions
@@ -825,11 +825,15 @@ buildRequiredPackageLists() {
 				;;
 			ddtrace@alpine)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent libgcc"
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile curl-dev automake libtool"
+				if test $PHP_MAJMIN_VERSION -lt 700; then
+					buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile curl-dev automake libtool"
+				fi
 				;;
 			ddtrace@debian)
-				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent $buildRequiredPackageLists_libssl"
-				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libcurl4-openssl-dev automake libtool"
+				if test $PHP_MAJMIN_VERSION -lt 700; then
+					buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent $buildRequiredPackageLists_libssl"
+					buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libcurl4-openssl-dev automake libtool"
+				fi
 				;;
 			dba@alpine)
 				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent db"
@@ -2979,6 +2983,39 @@ You may need to:
 EOT
 }
 
+# Install the Datadog PHP tracer
+#
+# Arguments:
+#   $1: the version to be installed (optional)
+installDDTrace() {
+	printf '# Installing ddtrace\n'
+	installDDTrace_version="${1:-}"
+	if test -z "$installDDTrace_version"; then
+		installDDTrace_url='https://github.com/DataDog/dd-trace-php/releases/latest/download/datadog-setup.php'
+	else
+		installDDTrace_url="https://github.com/DataDog/dd-trace-php/releases/download/$installDDTrace_version/datadog-setup.php"
+	fi
+	installDDTrace_setup="$(mktemp -p /tmp/src)"
+	printf 'Downloading datadog-setup.php from %s\n' "$installDDTrace_url"
+	if ! curl $IPE_CURL_FLAGS -sSLf -o "$installDDTrace_setup" "$installDDTrace_url"; then
+		printf 'Failed to download %s\n' "$installDDTrace_url" >&2
+		exit 1
+	fi
+	installDDTrace_args='--php-bin=php'
+	case "${IPE_DD_APPSEC:-}" in
+		1 | y* | Y*)
+			installDDTrace_args="$installDDTrace_args --enable-appsec"
+			;;
+	esac
+	case "${IPE_DD_PROFILING:-}" in
+		1 | y* | Y*)
+			installDDTrace_args="$installDDTrace_args --enable-profiling"
+			;;
+	esac
+	php "$installDDTrace_setup" $installDDTrace_args
+	rm -f "$installDDTrace_setup"
+}
+
 # Compile the libraries specified in the COMPILE_LIBS variable
 compileLibs() {
 	if stringInList libaom "$COMPILE_LIBS"; then
@@ -3452,25 +3489,24 @@ installRemoteModule() {
 			fi
 			;;
 		ddtrace)
-			if test -z "$installRemoteModule_version"; then
-				if test $PHP_MAJMIN_VERSION -lt 700; then
-					installRemoteModule_version=0.75.0
-				fi
-				if test -z "$installRemoteModule_version"; then
-					case "$DISTRO" in
-						alpine)
-							if test $DISTRO_MAJMIN_VERSION -le 312; then
-								# cc is not supported due to a memcmp related bug
-								installRemoteModule_version=1.1.0
-							fi
-							;;
-					esac
-				fi
-			else
+			if test -n "$installRemoteModule_version"; then
 				installRemoteModule_version="$(resolvePeclStabilityVersion "$installRemoteModule_module" "$installRemoteModule_version")"
 			fi
-			if test -z "$installRemoteModule_version" || test $(compareVersions "$installRemoteModule_version" 0.75.0) -ge 0; then
+			if test $PHP_MAJMIN_VERSION -lt 700; then
+				if test -n "$installRemoteModule_version" && test $(compareVersions "$installRemoteModule_version" 1.0.0) -ge 0; then
+					printf '### ERROR ### ddtrace %s requires PHP 7.0 or later (PHP %s is in use).\n' "$installRemoteModule_version" "$PHP_MAJDOTMIN_VERSION" >&2
+					exit 1
+				fi
+				if test -z "$installRemoteModule_version"; then
+					# newer 0.x releases reject PHP 5 in their configure script
+					installRemoteModule_version=0.75.0
+				fi
 				installCargo
+			elif test -n "$installRemoteModule_version" && test $(compareVersions "$installRemoteModule_version" 1.0.0) -lt 0; then
+				installCargo
+			else
+				installDDTrace "$installRemoteModule_version"
+				installRemoteModule_manuallyInstalled=2
 			fi
 			;;
 		decimal)

--- a/scripts/ci-test-extensions
+++ b/scripts/ci-test-extensions
@@ -343,7 +343,7 @@ testExtensionFor() {
 	printf ' - Docker image: %s\n' "$testExtensionFor_Image"
 	testExtensionFor_out="$(mktemp)"
 	testExtensionFor_start=$(date +%s)
-	if $(docker run --rm --volume "$CI_BUILD_DIR:/app" --env CI=true --env IPE_FIX_CACERTS=1 --env IPE_ASPELL_LANGUAGES='en fr' --workdir /app "$testExtensionFor_Image" sh -c "./install-php-extensions $1 && php ./scripts/check-installed-extension.php $1" >"$testExtensionFor_out" 2>&1); then
+	if $(docker run --rm --volume "$CI_BUILD_DIR:/app" --env CI=true --env IPE_FIX_CACERTS=1 --env IPE_DD_APPSEC=1 --env IPE_DD_PROFILING=1 --env IPE_ASPELL_LANGUAGES='en fr' --workdir /app "$testExtensionFor_Image" sh -c "./install-php-extensions $1 && php ./scripts/check-installed-extension.php $1" >"$testExtensionFor_out" 2>&1); then
 		testExtensionFor_end=$(date +%s)
 		testExtensionFor_delta=$(expr $testExtensionFor_end - $testExtensionFor_start)
 		rm -rf "$testExtensionFor_out"

--- a/scripts/ci-test-extensions
+++ b/scripts/ci-test-extensions
@@ -343,7 +343,22 @@ testExtensionFor() {
 	printf ' - Docker image: %s\n' "$testExtensionFor_Image"
 	testExtensionFor_out="$(mktemp)"
 	testExtensionFor_start=$(date +%s)
-	if $(docker run --rm --volume "$CI_BUILD_DIR:/app" --env CI=true --env IPE_FIX_CACERTS=1 --env IPE_DD_APPSEC=1 --env IPE_DD_PROFILING=1 --env IPE_ASPELL_LANGUAGES='en fr' --workdir /app "$testExtensionFor_Image" sh -c "./install-php-extensions $1 && php ./scripts/check-installed-extension.php $1" >"$testExtensionFor_out" 2>&1); then
+	testExtensionFor_ddtraceEnv=''
+	if stringInList ddtrace "$1"; then
+		case "$2" in
+			5.*) ;;
+			*)
+				testExtensionFor_ddtraceEnv="$testExtensionFor_ddtraceEnv --env IPE_DD_APPSEC=1"
+				;;
+		esac
+		case "$2" in
+			5.* | 7.0) ;;
+			*)
+				testExtensionFor_ddtraceEnv="$testExtensionFor_ddtraceEnv --env IPE_DD_PROFILING=1"
+				;;
+		esac
+	fi
+	if $(docker run --rm --volume "$CI_BUILD_DIR:/app" --env CI=true --env IPE_FIX_CACERTS=1 $testExtensionFor_ddtraceEnv --env IPE_ASPELL_LANGUAGES='en fr' --workdir /app "$testExtensionFor_Image" sh -c "./install-php-extensions $1 && php ./scripts/check-installed-extension.php $1" >"$testExtensionFor_out" 2>&1); then
 		testExtensionFor_end=$(date +%s)
 		testExtensionFor_delta=$(expr $testExtensionFor_end - $testExtensionFor_start)
 		rm -rf "$testExtensionFor_out"

--- a/scripts/tests/ddtrace
+++ b/scripts/tests/ddtrace
@@ -5,12 +5,23 @@ require_once __DIR__ . '/_bootstrap.php';
 
 $rc = 0;
 
-echo 'Checking if ddtrace_version() exists... ';
-if (!function_exists('ddtrace_version')) {
+// ddtrace 0.x exposed a global ddtrace_version() function; the 1.x line
+// (installed via datadog-setup.php) dropped it in favor of the
+// DD_TRACE_VERSION constant. phpversion() works across both, so use it as
+// the canonical check and fall back to the older APIs when present.
+echo 'Checking the ddtrace version... ';
+$ddtraceVersion = phpversion('ddtrace');
+if (($ddtraceVersion === false || $ddtraceVersion === '') && defined('DD_TRACE_VERSION')) {
+    $ddtraceVersion = DD_TRACE_VERSION;
+}
+if (($ddtraceVersion === false || $ddtraceVersion === '') && function_exists('ddtrace_version')) {
+    $ddtraceVersion = ddtrace_version();
+}
+if ($ddtraceVersion === false || $ddtraceVersion === '') {
     $rc = 1;
-    echo "NO!\n";
+    echo "unable to determine it!\n";
 } else {
-    echo 'yes (version: ' . ddtrace_version() . ").\n";
+    echo 'detected version ' . $ddtraceVersion . ".\n";
 }
 
 // When IPE_DD_PROFILING=1 was set during installation, the

--- a/scripts/tests/ddtrace
+++ b/scripts/tests/ddtrace
@@ -5,7 +5,7 @@ require_once __DIR__ . '/_bootstrap.php';
 
 $rc = 0;
 
-echo 'Checking, if ddtrace_version() exists... ';
+echo 'Checking if ddtrace_version() exists... ';
 if (!function_exists('ddtrace_version')) {
     $rc = 1;
     echo "NO!\n";

--- a/scripts/tests/ddtrace
+++ b/scripts/tests/ddtrace
@@ -1,0 +1,33 @@
+#!/usr/bin/env php
+<?php
+
+require_once __DIR__ . '/_bootstrap.php';
+
+$rc = 0;
+
+echo 'Checking if ddtrace_version() exists... ';
+if (!function_exists('ddtrace_version')) {
+    $rc = 1;
+    echo "NO!\n";
+} else {
+    echo 'yes (version: ' . ddtrace_version() . ").\n";
+}
+
+// When IPE_DD_PROFILING=1 was set during installation, the
+// datadog-profiling extension must also be loaded.
+$expectProfiling = (bool) getenv('IPE_DD_PROFILING');
+$hasProfiling = extension_loaded('datadog-profiling');
+if ($expectProfiling && !$hasProfiling) {
+    fwrite(STDERR, "Expected the datadog-profiling extension to be loaded but it is not.\n");
+    $rc = 1;
+}
+
+// Same for the AppSec module when IPE_DD_APPSEC=1 was set.
+$expectAppsec = (bool) getenv('IPE_DD_APPSEC');
+$hasAppsec = extension_loaded('ddappsec');
+if ($expectAppsec && !$hasAppsec) {
+    fwrite(STDERR, "Expected the ddappsec extension to be loaded but it is not.\n");
+    $rc = 1;
+}
+
+exit($rc);

--- a/scripts/tests/ddtrace
+++ b/scripts/tests/ddtrace
@@ -5,7 +5,7 @@ require_once __DIR__ . '/_bootstrap.php';
 
 $rc = 0;
 
-echo 'Checking if ddtrace_version() exists... ';
+echo 'Checking, if ddtrace_version() exists... ';
 if (!function_exists('ddtrace_version')) {
     $rc = 1;
     echo "NO!\n";


### PR DESCRIPTION
On PHP 7.0+ this PR switches the ddtrace installation path from the existing PECL + Cargo build to Datadog's official installer, `datadog-setup.php`. The PECL/Cargo path is preserved for PHP <7.0 and as a fallback when a user pins ddtrace to a version below 1.0.0.

### Why

- `datadog-setup.php` is Datadog's supported install path for the PHP tracer. Using it keeps the installation aligned with Datadog's release artifacts and version-pinning rules instead of relying on PECL's mirror of `datadog/dd-trace`.
- It can co-install the companion modules (`ddappsec`, `datadog-profiling`) in lockstep with the matching tracer build, which is awkward to do via PECL.
- It avoids building Rust from source via Cargo for the common case, which currently pulls `curl-dev automake libtool` (Alpine) or `libssl libcurl4-openssl-dev automake libtool` (Debian) and adds noticeable build time/image size.

### What changes

**`installRemoteModule()` — the `ddtrace)` branch (`install-php-extensions`)**

The selection logic is reorganized around the PHP version:

- **PHP <7.0** — unchanged path: build from source via PECL + `installCargo`. If a user explicitly requests `ddtrace-1.0.0` or newer on PHP <7.0, the script now errors out (`ddtrace <version> requires PHP 7.0 or later`) instead of silently failing later. With no version supplied, it still defaults to `0.75.0` (newer 0.x releases refuse PHP 5 in their `configure` script).
- **PHP 7.0+ with an explicit pre-1.0.0 version** — keep using the legacy `installCargo` path so older 0.x releases stay reproducible.
- **PHP 7.0+, default or 1.0.0+** — call the new `installDDTrace` helper and set `installRemoteModule_manuallyInstalled=2` so the surrounding code skips the standard PECL pipeline (this is the same convention used for other manually-installed modules like blackfire).

PECL stability flags (`stable`, `beta`, …) are still resolved via `resolvePeclStabilityVersion` before any of the branches above run.

**New `installDDTrace()` helper (`install-php-extensions`)**

```sh
installDDTrace [version]
```

- Downloads `datadog-setup.php` from the corresponding GitHub release:
  - no version → `https://github.com/DataDog/dd-trace-php/releases/latest/download/datadog-setup.php`
  - version `X.Y.Z` → `https://github.com/DataDog/dd-trace-php/releases/download/X.Y.Z/datadog-setup.php`
- Runs it as `php datadog-setup.php --php-bin=php [extra args]`.
- Honors two new environment variables (see below) to optionally append `--enable-appsec` and/or `--enable-profiling`.
- Uses `curl $IPE_CURL_FLAGS -sSLf` for the download so the existing `IPE_INSECURE=1` toggle keeps working, and errors out cleanly with a `### ERROR ### Failed to download …` message if the download fails.
- Cleans up the temporary `datadog-setup.php` once the install completes.

**New environment variables (`README.md`)**

| Variable | Effect |
| --- | --- |
| `IPE_DD_APPSEC=1` | Pass `--enable-appsec` to `datadog-setup.php`, installing the `ddappsec` module alongside ddtrace. Requires PHP 7.0+ and the 1.x tracer line. |
| `IPE_DD_PROFILING=1` | Pass `--enable-profiling` to `datadog-setup.php`, installing the `datadog-profiling` module. Requires PHP 7.1+ on Alpine 3.13+ (any Debian works) and the 1.x tracer line. |

Both follow the existing `IPE_*` env-var conventions (accept `1`, `y…`, `Y…`).

**`buildRequiredPackageLists()` — `ddtrace@alpine` and `ddtrace@debian` (`install-php-extensions`)**

The development packages that were unconditionally pulled in for ddtrace are now gated behind `PHP_MAJMIN_VERSION -lt 700`, because they're only needed by the Cargo build path:

- Alpine: `curl-dev automake libtool` — installed only on PHP <7.0.
- Debian: `$buildRequiredPackageLists_libssl libcurl4-openssl-dev automake libtool` — installed only on PHP <7.0.

For PHP 7.0+ the `datadog-setup.php` flow installs the prebuilt tracer binary, so none of these dev packages are needed.

**Test script: `scripts/tests/ddtrace`**

Adds an executable PHP test that:
1. Verifies `ddtrace_version()` is defined and prints the resolved version.
2. If `IPE_DD_PROFILING` was set during install, verifies the `datadog-profiling` extension is loaded.
3. If `IPE_DD_APPSEC` was set during install, verifies the `ddappsec` extension is loaded.

The script exits non-zero on any failure so it can be wired into the existing extension test matrix.

### Backwards compatibility

- `install-php-extensions ddtrace` on PHP <7.0 behaves exactly as before (default `0.75.0`, Cargo build, same build deps).
- `install-php-extensions ddtrace-<0.x.y>` on PHP 7.0+ keeps the previous Cargo-based path.
- The only behavioral change for existing users on PHP 7.0+ without a pinned version is the switch from the PECL/Cargo build to the official `datadog-setup.php` install — which yields the same `ddtrace` extension but no longer leaves `curl-dev`/`libcurl4-openssl-dev`/`automake`/`libtool` lingering as runtime-installed packages.

Closes #1163.