### PR TITLE
Pin xlswriter to 1.5.8 on Debian Jessie

### DIFF
--- a/install-php-extensions
+++ b/install-php-extensions
@@ -5152,6 +5152,14 @@ installRemoteModule() {
 			;;
 		xlswriter)
 			installRemoteModule_version="$(resolvePeclStabilityVersion "$installRemoteModule_module" "$installRemoteModule_version")"
+			if test -z "$installRemoteModule_version"; then
+				case "$DISTRO_VERSION" in
+					debian@8)
+						# The gcc version of Debian Jessie is too old => error: 'for' loop initial declarations are only allowed in C99 or C11 mode
+						installRemoteModule_version=1.5.8
+						;;
+				esac
+			fi
 			if test -z "$installRemoteModule_version" || test $(compareVersions "$installRemoteModule_version" 1.2.7) -ge 0; then
 				# enable reader supports?
 				addConfigureOption enable-reader yes


### PR DESCRIPTION
The nightly "Test recent" run for `master` is failing on Debian Jessie for both `php:7.0-cli-jessie` and `php:7.1-cli-jessie`. See [run 26323217533](https://github.com/mlocati/docker-php-extension-installer/actions/runs/26323217533) — \"Check on jessie\".

### Root cause

xlswriter 2.0.0 (the current PECL `stable`) introduced a new `zim_vtiful_xls_nextRowRich()` function in `kernel/excel.c` that uses a C99-style `for (int i = …)` declaration:

```
/tmp/pear/temp/xlswriter/kernel/excel.c:2638:17: error: 'for' loop initial declarations are only allowed in C99 or C11 mode
note: use option -std=c99, -std=gnu99, -std=c11 or -std=gnu11 to compile your code
…
Makefile:200: recipe for target 'kernel/excel.lo' failed
make: *** [kernel/excel.lo] Error 1
ERROR: `make -j4' failed
```

Debian Jessie ships GCC 4.9, which still defaults to `gnu89` and rejects loop-initial declarations. GCC 5+ (Stretch and later, all Alpines we test) defaults to `gnu11`, so every other distro in the matrix builds 2.0.0 fine — the failure is Jessie-only.

### Fix

Same pattern that is already used for `xmldiff` a few lines below in the same file: when no explicit version is requested and we are on `debian@8`, pin xlswriter to the last 1.x release, `1.5.8`. The `enable-reader yes` configure option (added by xlswriter 1.2.7+) keeps working since 1.5.8 is well above that threshold.

```sh
xlswriter)
    installRemoteModule_version="$(resolvePeclStabilityVersion "$installRemoteModule_module" "$installRemoteModule_version")"
    if test -z "$installRemoteModule_version"; then
        case "$DISTRO_VERSION" in
            debian@8)
                # The gcc version of Debian Jessie is too old => error: 'for' loop initial declarations are only allowed in C99 or C11 mode
                installRemoteModule_version=1.5.8
                ;;
        esac
    fi
    …
```

### Notes / scope

- Affects only `debian@8`. Other distros continue to install whatever the user (or PECL) considers current.
- A user can still opt back into 2.0.0 explicitly with `install-php-extensions xlswriter-2.0.0` — the pin only kicks in when no version is supplied (matching the `xmldiff` behavior).
- An alternative would be to inject `-std=gnu99` into `CFLAGS` for xlswriter on Jessie, but version pinning is consistent with the existing precedent in this file and keeps the change minimal.