### PR TITLE
Fix SaxonC URL for version >=12.6

### DIFF
--- a/install-php-extensions
+++ b/install-php-extensions
@@ -4354,7 +4354,16 @@ installRemoteModule() {
 			installRemoteModule_majorVersion=
 			if test -n "$installRemoteModule_version"; then
 				installRemoteModule_majorVersion="${installRemoteModule_version%%.*}"
-				if test "$installRemoteModule_majorVersion" -ge 12; then
+				if test "$installRemoteModule_majorVersion" -ge 12 && test $(compareVersions "$installRemoteModule_version" '12.6') -ge 0; then
+					installRemoteModule_versionDashed="$installRemoteModule_version"
+					case "$installRemoteModule_versionDashed" in
+						*.*.*) ;;
+						*.*) installRemoteModule_versionDashed="${installRemoteModule_versionDashed}.0" ;;
+						*) installRemoteModule_versionDashed="${installRemoteModule_versionDashed}.0.0" ;;
+					esac
+					installRemoteModule_versionDashed="$(echo "$installRemoteModule_versionDashed" | tr '.' '-')"
+					installRemoteModule_url=https://downloads.saxonica.com/SaxonC/${installRemoteModule_edition}/${installRemoteModule_majorVersion}/SaxonC${installRemoteModule_edition}-${installRemoteModule_architecture}-${installRemoteModule_versionDashed}.zip
+				elif test "$installRemoteModule_majorVersion" -ge 12; then
 					installRemoteModule_url=https://downloads.saxonica.com/SaxonC/${installRemoteModule_edition}/${installRemoteModule_majorVersion}/libsaxon-${installRemoteModule_edition}C-${installRemoteModule_architecture}-v${installRemoteModule_version}.zip
 				else
 					installRemoteModule_url=https://downloads.saxonica.com/SaxonC/${installRemoteModule_edition}/${installRemoteModule_majorVersion}/libsaxon-${installRemoteModule_edition}C-setup64-v${installRemoteModule_version}.zip


### PR DESCRIPTION
Starting with SaxonC v12.6, Saxonica renamed their release archives. Passing an explicit version >= 12.6 to `install-php-extensions saxon-<version>` results in a 404 because the legacy URL pattern no longer exists on their server.

**Before v12.6** :
  https://downloads.saxonica.com/SaxonC/HE/12/libsaxon-HEC-linux-x86_64-v12.5.zip

**Since v12.6**:
  https://downloads.saxonica.com/SaxonC/HE/12/SaxonCHE-linux-x86_64-12-6-0.zip

Two things changed:
  1. Archive prefix: `libsaxon-${edition}C-` → `SaxonC${edition}-`
  2. Version format: `v12.6` (dotted, prefixed) → `12-6-0` 

Official listing: https://downloads.saxonica.com/SaxonC/HE/12/index.html