### PR TITLE
Add Ghostscript to persistent package list for ImageMagick

### DIFF
--- a/install-php-extensions
+++ b/install-php-extensions
@@ -1081,6 +1081,7 @@ buildRequiredPackageLists() {
 				else
 					buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ^libmagickwand-6.q16-[0-9]+$ ^libmagickcore-6.q16-[0-9]+-extra$"
 				fi
+				buildRequiredPackageLists_persistent="$buildRequiredPackageLists_persistent ghostscript"
 				buildRequiredPackageLists_volatile="$buildRequiredPackageLists_volatile libmagickwand-dev"
 				;;
 			imap@alpine)

--- a/scripts/tests/imagick
+++ b/scripts/tests/imagick
@@ -5,13 +5,6 @@ require_once __DIR__ . '/_bootstrap.php';
 
 list($os, $osVersion) = inspectOS();
 
-// For every format we require, define how to obtain a test sample so we can
-// actually exercise the format instead of just trusting Imagick::queryFormats():
-//   true     => let Imagick encode the sample itself, then read it back
-//               (round-trip: exercises both the encoder and the decoder).
-//   <string> => a literal sample already in that format, which we only read back
-//               (exercises the decoder; used for formats Imagick can't reliably
-//               write, but whose reading relies on an external delegate).
 $requiredFormats = [
     'BMP' => true,
     'GIF' => true,
@@ -40,11 +33,6 @@ switch ($os) {
         exit(1);
 }
 
-// Reading a PDF is delegated to Ghostscript, but ImageMagick also has to allow
-// its "PDF" coder. ImageMagick 6 (Debian up to bookworm) ships a policy.xml that
-// disables the PDF/PS coders (rights="none"), so PDF support only works from
-// ImageMagick 7 onwards (e.g. Debian trixie; Alpine already uses ImageMagick 7).
-// Only require/exercise PDF there, and via reading -- we never write PDFs.
 if (preg_match('/ImageMagick\s+(\d+)/', Imagick::getVersion()['versionString'], $m) && (int) $m[1] >= 7) {
     $requiredFormats['PDF'] = "%PDF-1.4\n"
         . "1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n"
@@ -55,12 +43,13 @@ if (preg_match('/ImageMagick\s+(\d+)/', Imagick::getVersion()['versionString'], 
         . "endstream endobj\n"
         . "trailer<</Root 1 0 R>>\n"
         . '%%EOF';
+} else {
+    $requiredFormats['PDF'] = false;
 }
 
 $requiredFormats = array_change_key_case($requiredFormats, CASE_UPPER);
 ksort($requiredFormats);
 
-// Quick pre-check: every required format must at least be a registered coder.
 $supportedFormats = array_map('strtoupper', Imagick::queryFormats());
 $missingFormats = array_diff(array_keys($requiredFormats), $supportedFormats);
 if ($missingFormats !== []) {
@@ -69,18 +58,17 @@ if ($missingFormats !== []) {
     exit(1);
 }
 
-// Actually exercise every format: encode a sample (when Imagick can write it),
-// then decode it. Decoding is what invokes the external delegates -- e.g.
-// Ghostscript for PDF and librsvg for SVG -- so this catches a missing delegate
-// that queryFormats() alone would happily hide.
 $allGood = true;
 foreach ($requiredFormats as $format => $sample) {
+    if ($sample === false) {
+        continue;
+    }
     try {
         if ($sample === true) {
             $writer = new Imagick();
             $writer->newImage(16, 16, new ImagickPixel('blue'));
             $writer->setImageFormat($format);
-            $blob = $writer->getImageBlob(); // Exercise the encoder
+            $blob = $writer->getImageBlob();
             $writer->destroy();
         } else {
             $blob = $sample;
@@ -89,12 +77,12 @@ foreach ($requiredFormats as $format => $sample) {
         if ($format === 'PDF') {
             $reader->setResolution(72, 72);
         }
-        $reader->readImageBlob($blob, 'sample.' . strtolower($format)); // Exercise the decoder/delegate
+        $reader->readImageBlob($blob, 'sample.' . strtolower($format));
         if ($reader->getImageWidth() < 1 || $reader->getImageHeight() < 1) {
             throw new ImagickException('the decoded image has no pixels');
         }
         $reader->setImageFormat('PNG');
-        $reader->getImageBlob(); // Force the sample to be fully decoded/rasterized
+        $reader->getImageBlob();
         $reader->destroy();
     } catch (ImagickException $x) {
         fwrite(STDERR, "Imagick failed to handle format {$format}: {$x->getMessage()}\n");

--- a/scripts/tests/imagick
+++ b/scripts/tests/imagick
@@ -63,6 +63,7 @@ foreach ($requiredFormats as $format => $sample) {
     if ($sample === false) {
         continue;
     }
+
     try {
         if ($sample === true) {
             $writer = new Imagick();

--- a/scripts/tests/imagick
+++ b/scripts/tests/imagick
@@ -9,10 +9,12 @@ $requiredFormats = [
     'BMP' => true,
     'GIF' => true,
     'JPG' => true,
-    'PDF' => false,
+    'PDF' => true,
     'PNG' => true,
-    'SVG' => false,
-    'TIFF' => false,
+    'SVG' => '<?xml version="1.0" encoding="UTF-8"?>' . "\n"
+        . '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">'
+        . '<rect width="16" height="16" fill="green"/></svg>',
+    'TIFF' => true,
 ];
 switch ($os) {
     case 'alpine':
@@ -34,6 +36,8 @@ switch ($os) {
 
 $requiredFormats = array_change_key_case($requiredFormats, CASE_UPPER);
 ksort($requiredFormats);
+
+// Quick pre-check: every required format must at least be a registered coder.
 $supportedFormats = array_map('strtoupper', Imagick::queryFormats());
 $missingFormats = array_diff(array_keys($requiredFormats), $supportedFormats);
 if ($missingFormats !== []) {
@@ -41,24 +45,38 @@ if ($missingFormats !== []) {
     fwrite(STDERR, "Imagick does NOT support these formats:\n- " . implode("\n- ", $missingFormats) . "\n");
     exit(1);
 }
-$image = new Imagick();
-$image->newImage(8, 8, new ImagickPixel('red'));
-$allGood = true;
 
-try {
-    foreach ($requiredFormats as $format => $writeSupport) {
-        if ($writeSupport) {
-            try {
-                $image->setImageFormat($format);
-                $image->getImageBlob(); // Force the image to be written in the specified format
-            } catch (ImagickException $x) {
-                fwrite(STDERR, "Imagick failed to write in format {$format}: {$x->getMessage()}\n");
-                $allGood = false;
-            }
+// Actually exercise every format: encode a sample (when Imagick can write it),
+// then decode it. Decoding is what invokes the external delegates -- e.g.
+// Ghostscript for PDF and librsvg for SVG -- so this catches a missing delegate
+// that queryFormats() alone would happily hide.
+$allGood = true;
+foreach ($requiredFormats as $format => $sample) {
+    try {
+        if ($sample === true) {
+            $writer = new Imagick();
+            $writer->newImage(16, 16, new ImagickPixel('blue'));
+            $writer->setImageFormat($format);
+            $blob = $writer->getImageBlob(); // Exercise the encoder
+            $writer->destroy();
+        } else {
+            $blob = $sample;
         }
+        $reader = new Imagick();
+        if ($format === 'PDF') {
+            $reader->setResolution(72, 72);
+        }
+        $reader->readImageBlob($blob, 'sample.' . strtolower($format)); // Exercise the decoder/delegate
+        if ($reader->getImageWidth() < 1 || $reader->getImageHeight() < 1) {
+            throw new ImagickException('the decoded image has no pixels');
+        }
+        $reader->setImageFormat('PNG');
+        $reader->getImageBlob(); // Force the sample to be fully decoded/rasterized
+        $reader->destroy();
+    } catch (ImagickException $x) {
+        fwrite(STDERR, "Imagick failed to handle format {$format}: {$x->getMessage()}\n");
+        $allGood = false;
     }
-} finally {
-    $image->destroy();
 }
 
 if ($allGood) {

--- a/scripts/tests/imagick
+++ b/scripts/tests/imagick
@@ -9,7 +9,6 @@ $requiredFormats = [
     'BMP' => true,
     'GIF' => true,
     'JPG' => true,
-    'PDF' => true,
     'PNG' => true,
     'SVG' => '<?xml version="1.0" encoding="UTF-8"?>' . "\n"
         . '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">'
@@ -34,6 +33,18 @@ switch ($os) {
         exit(1);
 }
 
+if (preg_match('/ImageMagick\s+(\d+)/', Imagick::getVersion()['versionString'], $m) && (int) $m[1] >= 7) {
+    $requiredFormats['PDF'] = "%PDF-1.4\n"
+        . "1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n"
+        . "2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n"
+        . "3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 72 72]/Resources<<>>/Contents 4 0 R>>endobj\n"
+        . "4 0 obj<</Length 22>>stream\n"
+        . "1 0 0 rg 0 0 72 72 re f\n"
+        . "endstream endobj\n"
+        . "trailer<</Root 1 0 R>>\n"
+        . "%%EOF";
+}
+
 $requiredFormats = array_change_key_case($requiredFormats, CASE_UPPER);
 ksort($requiredFormats);
 
@@ -46,10 +57,6 @@ if ($missingFormats !== []) {
     exit(1);
 }
 
-// Actually exercise every format: encode a sample (when Imagick can write it),
-// then decode it. Decoding is what invokes the external delegates -- e.g.
-// Ghostscript for PDF and librsvg for SVG -- so this catches a missing delegate
-// that queryFormats() alone would happily hide.
 $allGood = true;
 foreach ($requiredFormats as $format => $sample) {
     try {

--- a/scripts/tests/imagick
+++ b/scripts/tests/imagick
@@ -5,6 +5,13 @@ require_once __DIR__ . '/_bootstrap.php';
 
 list($os, $osVersion) = inspectOS();
 
+// For every format we require, define how to obtain a test sample so we can
+// actually exercise the format instead of just trusting Imagick::queryFormats():
+//   true     => let Imagick encode the sample itself, then read it back
+//               (round-trip: exercises both the encoder and the decoder).
+//   <string> => a literal sample already in that format, which we only read back
+//               (exercises the decoder; used for formats Imagick can't reliably
+//               write, but whose reading relies on an external delegate).
 $requiredFormats = [
     'BMP' => true,
     'GIF' => true,
@@ -33,16 +40,21 @@ switch ($os) {
         exit(1);
 }
 
+// Reading a PDF is delegated to Ghostscript, but ImageMagick also has to allow
+// its "PDF" coder. ImageMagick 6 (Debian up to bookworm) ships a policy.xml that
+// disables the PDF/PS coders (rights="none"), so PDF support only works from
+// ImageMagick 7 onwards (e.g. Debian trixie; Alpine already uses ImageMagick 7).
+// Only require/exercise PDF there, and via reading -- we never write PDFs.
 if (preg_match('/ImageMagick\s+(\d+)/', Imagick::getVersion()['versionString'], $m) && (int) $m[1] >= 7) {
     $requiredFormats['PDF'] = "%PDF-1.4\n"
         . "1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n"
         . "2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n"
         . "3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 72 72]/Resources<<>>/Contents 4 0 R>>endobj\n"
-        . "4 0 obj<</Length 22>>stream\n"
+        . "4 0 obj<</Length 23>>stream\n"
         . "1 0 0 rg 0 0 72 72 re f\n"
         . "endstream endobj\n"
         . "trailer<</Root 1 0 R>>\n"
-        . "%%EOF";
+        . '%%EOF';
 }
 
 $requiredFormats = array_change_key_case($requiredFormats, CASE_UPPER);
@@ -57,6 +69,10 @@ if ($missingFormats !== []) {
     exit(1);
 }
 
+// Actually exercise every format: encode a sample (when Imagick can write it),
+// then decode it. Decoding is what invokes the external delegates -- e.g.
+// Ghostscript for PDF and librsvg for SVG -- so this catches a missing delegate
+// that queryFormats() alone would happily hide.
 $allGood = true;
 foreach ($requiredFormats as $format => $sample) {
     try {


### PR DESCRIPTION
This pull request makes a small update to the `install-php-extensions` script to improve dependency handling for ImageMagick extensions.

- Added `ghostscript` to the list of persistent required packages when installing ImageMagick-related PHP extensions, ensuring better compatibility and support for image processing features.

The Alpine variant already has it, but it's missing on Debian. It is required for PDF handling. 