### PR TITLE
fix time64 package rename in debian 13 for libssl3

### DIFF
--- a/install-php-extensions
+++ b/install-php-extensions
@@ -771,7 +771,11 @@ buildRequiredPackageLists() {
 							buildRequiredPackageLists_libssldev="libssl-dev"
 						fi
 					else
-						buildRequiredPackageLists_libssl="libssl$buildRequiredPackageLists_sslMajorVersion"
+						if test $DISTRO_VERSION_NUMBER -ge 13; then
+							buildRequiredPackageLists_libssl="^libssl${buildRequiredPackageLists_sslMajorVersion}(t64)?\$"
+						else
+							buildRequiredPackageLists_libssl="libssl$buildRequiredPackageLists_sslMajorVersion"
+						fi
 						buildRequiredPackageLists_libssldev="libssl-dev"
 					fi
 					;;


### PR DESCRIPTION
similar issue as in #1247 

Ref: 
- https://packages.debian.org/trixie/i386/libssl3t64/filelist for 32bit systems also available
- https://packages.debian.org/search?searchon=names&keywords=libssl3 