### PR TITLE
Fix wikidiff2 on php:8.1

### DIFF
--- a/install-php-extensions
+++ b/install-php-extensions
@@ -5185,6 +5185,8 @@ installRemoteModule() {
 			if test -z "$installRemoteModule_version"; then
 				if test $PHP_MAJMIN_VERSION -le 702; then
 					installRemoteModule_version=1.13.0
+				elif test $PHP_MAJMIN_VERSION -le 801; then
+					installRemoteModule_version=1.14.1
 				else
 					installRemoteModule_version="$(git -c versionsort.suffix=- ls-remote --tags --refs --quiet --exit-code --sort=version:refname https://github.com/wikimedia/mediawiki-php-wikidiff2.git 'refs/tags/*.*.*' | tail -1 | cut -d/ -f3)"
 				fi


### PR DESCRIPTION
Fix wikidiff2 on php:8.1

Example failure is [here](https://github.com/mlocati/docker-php-extension-installer/actions/runs/27313201250/job/80687936709)